### PR TITLE
feat: Add drag-and-drop ordering and movement for categories & items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "packing-list",
       "version": "0.1.0",
       "dependencies": {
-        "vue": "^3.5.21"
+        "vue": "^3.5.21",
+        "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^4.6.2",
@@ -1774,6 +1775,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w=="
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2097,6 +2103,17 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write \"source/**/*.{js,vue,css,html,json,md}\""
   },
   "dependencies": {
-    "vue": "^3.5.21"
+    "vue": "^3.5.21",
+    "vuedraggable": "^4.1.0"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.6.2",

--- a/product-spec.md
+++ b/product-spec.md
@@ -5,15 +5,44 @@
 A web application that helps users manage travel packing. It supports category management, progress tracking, and a responsive user experience.
 
 ## 2. Definitions
-- Checklist: A container for a trip that includes destination and travel dates, with optional notes.
-- Category: A primary classification of items such as clothing, toiletries, electronics, etc.
-- Item: A specific thing to bring, with name, quantity, and packing status.
+Checklist, Category, and Item are the three core data entities of the app. Below are concise definitions, common fields, and examples:
+
+- Checklist
+  - Description: A packing list container for a trip that includes trip info and its associated categories and items.
+  - Properties:
+    - id: string (unique identifier)
+    - destination: string (destination)
+    - startDate: string (start date, ISO format)
+    - endDate: string (end date, ISO format)
+  - Example: { id: "c1", destination: "Tokyo", startDate: "2025-12-01", endDate: "2025-12-07" }
+
+- Category
+  - Description: A grouping/label for items within a checklist (e.g., clothing, toiletries).
+  - Properties:
+    - id: string (unique identifier)
+    - name: string (category name)
+    - checklistId: string (owning checklist ID)
+    - order: number (display/sort priority, default 0)
+  - Example: { id: "cat-travel-clothes", name: "Clothing", checklistId: "c1", order: 0 }
+
+- Item
+  - Description: A single item entry in a checklist, with quantity and packing status; can be reordered or moved between categories.
+  - Properties:
+    - id: string (unique identifier)
+    - name: string (item name)
+    - quantity: number (quantity)
+    - categoryId: string (owning category ID)
+    - isPacked: boolean (packed status)
+    - checklistId: string (owning checklist ID)
+    - order: number (display/sort priority, default 0)
+  - Example: { id: "item-01", name: "T-shirt", quantity: 3, categoryId: "cat-travel-clothes", isPacked: false, checklistId: "c1", order: 10 }
 
 ## 3. Technology Stack
 ### Frontend
 - Framework: Vue.js 3 (Composition API)
 - Build Tool: Vite 4.4.9
 - CSS Framework: Tailwind CSS 3.4.17
+- Drag and Drop: vuedraggable 4.1.0
 - Additional Tools: PostCSS, Autoprefixer
 
 ### Data Storage
@@ -28,43 +57,116 @@ A web application that helps users manage travel packing. It supports category m
 ## 4. Implemented Features
 
 ### Core Functionality
+
 #### Checklist Management
-- Create multiple trip checklists. Each checklist includes:
-  - Destination (destination)
-  - Start and end dates (startDate, endDate)
-  - Notes (optional)
-- Edit basic checklist information
-- Delete a checklist
-- Switch between checklists
+- Purpose: Let users manage multiple packing lists and create a new list for each trip.
+- Key features:
+  - Create checklist: Auto-seed default categories and items from `source/data/defaultItems.js`.
+    - Categories: Built from default data by removing duplicate category names; assign `order` based on creation sequence (starting at 0).
+    - Items: Created one by one with the correct `categoryId`, `isPacked=false`, and sequential `order` (starting at 0).
+  - Edit checklist: Edit `destination`, `startDate`, `endDate` (native date inputs, ISO format).
+  - Delete checklist: Cascade delete all categories and items under the checklist.
+  - Switch checklist: Load that checklist’s categories and items, sorted by `order`.
+- Flow: Create checklist → add categories/items → edit info → switch checklists.
+- Validation:
+  - After create:
+    - Categories count equals the number of distinct category names in default data; each `checklistId` equals the new checklist ID; `order` is continuous from 0.
+    - Items count equals default total; each has `isPacked=false`, correct `categoryId`, and `order` continuous from 0.
+    - localStorage (key: `packingListApp`) contains the new data; persists after reload.
+  - Edit: UI updates immediately and persists; dates are `YYYY-MM-DD`.
+  - Delete: Checklist, categories, and items are all removed from localStorage; UI switches to another list or empty state.
+  - Switch: Categories/items load sorted by `order`; progress bar reflects the current checklist.
 
 #### Category Management
-- Add custom categories
-- Edit category names
-- Delete a category (also deletes items under it)
-- Show a per-category progress bar
+- Purpose: Organize items within a checklist to improve browsing and management.
+- Key features:
+  - Add category: Appends to the end, `order = current max order + 1`.
+  - Rename category: Inline edit and persist on save/blur.
+  - Delete category: Cascade delete all items under it.
+  - Reorder categories: Drag to update `order` (starting at 0); persists and remains after reload.
+  - Progress display: Calculate completion percentage based on `isPacked` of items within the category.
+- Flow: Add → rename → delete → drag to reorder.
+- Validation:
+  - After add: Category `order` is last; localStorage updates; order persists after reload.
+  - After delete: Its items disappear from UI and localStorage.
+  - After drag: Each category `order` is continuous from 0; order persists after reload.
+  - Progress: Completed/total syncs with item check/uncheck.
 
 #### Item Management
-- Add items under a specific category
-- Item properties include:
-  - Name (name)
-  - Quantity (quantity)
-  - Category reference (categoryId)
-  - Packing status (isPacked)
-- Inline edit name and quantity
-- Toggle packing status
-- Delete items
+- Purpose: Manage individual item entries in a checklist, supporting create/edit/delete, toggle packing, and drag reorder/move; updates progress in real time.
+- Key features:
+  - Create item: In a specified category, `isPacked=false`, `order = max order of that category + 1`.
+  - Edit item: Inline edit name and quantity (min 1); delete item.
+  - Toggle status: Toggling `isPacked` immediately updates category and checklist progress; preserves `order`.
+  - Dragging:
+    - Same category: After reorder, rewrite `order` sequentially (0-based).
+    - Cross category: Update target item’s `categoryId` and `order`, and adjust both source and target categories’ other items to keep `order` continuous.
+- Flow: Add → edit → check/uncheck → delete or drag to reorder/move.
+- Validation:
+  - After add: Item `order` is last, `isPacked=false`; localStorage updates and persists after reload.
+  - After edit/delete: UI updates and persists; deleted item removed from UI and localStorage.
+  - Same-category reorder: Each item `order` is continuous from 0; persists after reload.
+  - Cross-category move: Target `categoryId` and `order` are correct; remaining items in both categories have continuous `order`; progress updates correctly on both sides.
 
 #### Progress Tracking
-- Show overall checklist progress
-- Calculate and display per-category progress
-- Visual progress bar component
-- Real-time updates on changes
+- Purpose: Provide immediate, visual feedback of completion at both checklist and category levels.
+- Key features:
+  - Checklist progress: `total = items.length`, `completed = items.filter(isPacked).length`; shown under the checklist header (`ProgressBar.vue`).
+  - Category progress: Based on that category’s `sortedItems.length` and `isPacked` counts; shown on the category card (`Category.vue`).
+  - Percentage formula: `Math.round(completed / total * 100)`; when `total = 0`, returns `0` (`ProgressBar.vue`).
+  - Completed styling: When all items in a category are packed and the list is non-empty, the card shows a completed background style.
+- Flow:
+  - Check/uncheck items → category and checklist progress update immediately.
+  - Add/delete/drag items → progress recalculates automatically.
+  - Switch checklist → progress recalculates for the selected list.
+- Validation:
+  - Empty set: `total=0` displays `0%`; no divide-by-zero/NaN.
+  - Rounding: e.g., 1/3 → `33%`, 2/3 → `67%`.
+  - Completed style: Category turns green only when non-empty and fully packed.
+  - Persistence: Packing status saved in localStorage; progress matches UI after reload.
+  - Cross-category moves: Source/target category completion updates correctly; checklist total progress stays correct.
 
 #### Responsive Design
-- Desktop: Sidebar + main content layout
-- Tablet/Narrow screens: Collapsible sidebar with overlay mode
-- Mobile: Top bar + drawer-style sidebar
-- Responsive grid layout (1–4 columns)
+- Purpose: Offer a smooth, usable experience across devices and viewport widths.
+- Key features:
+  - Breakpoints & behavior:
+    - Mobile (<600px): Show `Topbar` (`md:hidden`), `Sidebar` as an overlay drawer (teleport to `body` with dimmed backdrop; click backdrop to close); main content blurs and pointer events are disabled.
+    - Narrow desktop (<1000px): `Sidebar` also uses overlay drawer mode.
+    - Desktop (≥1000px): `Sidebar` is sticky (fixed within layout) and can expand (`w-52`) or collapse (`w-16`); manual collapse state is remembered in `localStorage('sidebar-manually-collapsed')`.
+  - Content layout:
+    - Categories masonry: CSS columns via `categories-masonry`, with `column-count` adapting to 1 (<600), 2 (≥600), 3 (≥840), 4 (≥1280).
+    - No card breaks: Category wrappers use `break-inside: avoid` with smooth transitions to reduce jitter.
+  - Usability:
+    - When the drawer is open, set `document.body.style.overflow='hidden'` to prevent background scroll; transitions around 200–300ms.
+- Flow:
+  - Layout switches automatically based on viewport; mobile toggles `Sidebar` via hamburger; desktop can manually collapse/expand and the state is remembered.
+- Validation:
+  - Switching sizes between <600, 600–999, and ≥1000 verifies `Topbar`, `Sidebar` drawer/fixed modes, and main-content blur behavior.
+  - Drawer open: main content is blurred and non-interactive; clicking backdrop closes the drawer; body scroll restores after close.
+  - Desktop refresh: `Sidebar` collapse state reflects `localStorage` value.
+  - Masonry columns adjust at breakpoints; category cards don’t break across columns.
+
+#### Drag and Drop
+- Purpose: Quickly reorder and reorganize categories/items by dragging, keeping orders consistent with minimal effort.
+- Key features:
+  - Item dragging (`Category.vue` with `vuedraggable` group: `items`):
+    - Same-category reorder: On drop, rewrite all items’ `order = 0..n` in that category; `isPacked` unchanged.
+    - Cross-category move: Update the moved item’s `categoryId` and `order = evt.newIndex`; shift subsequent items in the target category (`order + 1` after the insertion point) and renumber the source category (`order = 0..n`).
+    - Drop restriction: Only allow drops within item containers (`group.put` check).
+  - Category dragging (`Checklist.vue` with `vuedraggable` group: `categories`):
+    - Reorder categories within a checklist; after drop, set categories’ `order = 0..n`.
+    - Drop restriction: Only allow drops within the categories container.
+  - Visuals & motion:
+    - `ghost/chosen/drag` classes for translucent, grab, and scale effects, ~200ms animations; keep masonry layout stable while dragging.
+  - Persistence:
+    - Drag events are handled by parent logic to call `updateItem`/`updateCategory` and then `getItems`/`getCategories` to ensure consistency; orders persist across reloads.
+- Flow:
+  - Press and hold on an item or category → drag to the target position/category → drop → reorder/save.
+- Validation:
+  - Same-category: `items.order` is continuous from 0; persists after reload.
+  - Cross-category: Target item’s `categoryId`/`order` correct; other items in both categories have continuous `order`; both categories’ and overall progress update immediately.
+  - Categories: All `categories.order` are continuous from 0; persists after reload.
+  - UX: Drag visuals present; animations are smooth without noticeable jitter/flicker.
 
 ### Technical Implementation
 #### Architecture Pattern
@@ -87,39 +189,39 @@ A web application that helps users manage travel packing. It supports category m
 ```
 packing-list/
 ├── index.html                          # Entry HTML
+├── LICENSE                             # License terms
 ├── package.json                        # Dependencies and scripts
-├── vite.config.js                      # Vite build config
-├── tailwind.config.js                  # Tailwind CSS config
 ├── postcss.config.js                   # PostCSS config
+├── tailwind.config.js                  # Tailwind CSS config
+├── vite.config.js                      # Vite build config
 └── source/                             # Application source
-    ├── main.js                         # App entry point (createApp + mount)
-    ├── App.vue                         # Root component
-    ├── index.css                       # Global styles and Tailwind imports
-    ├── models/                         # Domain models
-    │   ├── Checklist.js                # Checklist model
-    │   ├── Category.js                 # Category model
-    │   └── Item.js                     # Item model
-    ├── services/                       # Data access layer
-    │   ├── dataService.js              # Abstract data service interface
-    │   └── localStorageService.js      # LocalStorage implementation
-    ├── composables/                    # Vue composables (state + logic)
-    │   └── usePackingLists.js          # Core state and CRUD logic
-    ├── components/                     # UI components
-    │   ├── Sidebar.vue                 # Sidebar navigation
-    │   ├── Topbar.vue                  # Top bar for mobile
-    │   ├── Checklist.vue               # Main checklist view
-    │   ├── ChecklistForm.vue           # Checklist edit form
-    │   ├── Category.vue                # Category card
-    │   ├── Item.vue                    # Item row/card
-    │   ├── ProgressBar.vue             # Progress bar component
-    │   ├── AddCategoryButton.vue       # Add category button
-    │   ├── AddItemButton.vue           # Add item button
-    │   └── OverflowMenu.vue            # Overflow actions menu
-    ├── utils/                          # Utilities
-    │   ├── constants.js                # App constants
-    │   └── helpers.js                  # Helper functions (e.g., ID generation)
-    └── data/                           # Static data
-        └── defaultItems.js             # Default items for new checklists
+  ├── App.vue                         # Root component
+  ├── index.css                       # Global styles and Tailwind imports
+  ├── main.js                         # App entry point (createApp + mount)
+  ├── components/                     # UI components
+  │   ├── AddCategoryButton.vue       # Add category button
+  │   ├── AddItemButton.vue           # Add item button
+  │   ├── Category.vue                # Category card
+  │   ├── Checklist.vue               # Main checklist view
+  │   ├── Item.vue                    # Item row/card
+  │   ├── OverflowMenu.vue            # Overflow actions menu
+  │   ├── ProgressBar.vue             # Progress bar component
+  │   ├── Sidebar.vue                 # Sidebar navigation
+  │   └── Topbar.vue                  # Top bar for mobile
+  ├── composables/                    # Vue composables (state + logic)
+  │   └── usePackingLists.js          # Core state and CRUD logic
+  ├── data/                           # Static data
+  │   └── defaultItems.js             # Default items for new checklists
+  ├── models/                         # Domain models
+  │   ├── Category.js                 # Category model
+  │   ├── Checklist.js                # Checklist model
+  │   └── Item.js                     # Item model
+  ├── services/                       # Data access layer
+  │   ├── dataService.js              # Abstract data service interface
+  │   └── localStorageService.js      # LocalStorage implementation
+  └── utils/                          # Utilities
+    ├── constants.js                # App constants
+    └── helpers.js                  # Helper functions (e.g., ID generation)
 ```
 
 ## 6. UI/UX Design
@@ -140,9 +242,9 @@ packing-list/
 - Spacing: Tailwind spacing scale for consistency
 
 ### Responsive Breakpoints
-- Mobile: `< 768px` — vertical layout, top bar
-- Tablet: `768px–900px` — collapsible sidebar
-- Desktop: `> 900px` — fixed sidebar layout
+- Mobile: `< 600px` — vertical layout, show Topbar (`md:hidden`)
+- Narrow desktop: `600px–999px` — Sidebar as overlay drawer
+- Desktop: `≥ 1000px` — Fixed Sidebar with expandable/collapsible state (remembered)
 
 ### Interaction Design
 #### Sidebar Behavior
@@ -161,11 +263,10 @@ packing-list/
 |---------------|-------------------------------------|--------------|
 | Sidebar       | Checklist navigation and management | Responsive collapse/expand; checklist selection      |
 | Topbar        | Mobile navigation bar               | Hamburger menu; quick add checklist                |
-| Checklist     | Main content area                   | Shows categories and items for the selected checklist       |
-| Category      | Category card                       | Lists items; shows progress; edit actions                  |
-| Item          | Item row/card                       | Toggle packed; inline edit; delete                   |
+| Checklist     | Main content area                   | Shows categories and items for the selected checklist; drag and drop for category reordering; masonry layout       |
+| Category      | Category card                       | Lists items; shows progress; edit actions; drag and drop for item reordering and movement                  |
+| Item          | Item row/card                       | Toggle packed; inline edit; delete; draggable within/between categories                   |
 | ProgressBar   | Progress visualization              | Displays completion percentage               |
-| ChecklistForm | Checklist form                      | Create/edit checklist information              |
 | OverflowMenu  | Overflow actions                    | Edit/delete and other actions                  |
 
 ## 7. Data Models
@@ -185,7 +286,8 @@ packing-list/
 {
   id: string,           // Unique identifier
   name: string,         // Category name
-  checklistId: string   // Owning checklist ID
+  checklistId: string,  // Owning checklist ID
+  order: number         // Display order (default: 0)
 }
 ```
 
@@ -197,6 +299,7 @@ packing-list/
   quantity: number,     // Quantity
   categoryId: string,   // Category ID
   isPacked: boolean,    // Packed status
-  checklistId: string   // Owning checklist ID
+  checklistId: string,  // Owning checklist ID
+  order: number         // Display order (default: 0)
 }
 ```

--- a/source/App.vue
+++ b/source/App.vue
@@ -116,8 +116,8 @@ const SIDEBAR_COLLAPSED_KEY = 'sidebar-manually-collapsed';
 
 // Responsive breakpoints
 const BREAKPOINTS = {
-  MOBILE: 768, // md breakpoint
-  SIDEBAR_OVERLAY: 900 // width under which sidebar becomes overlay
+  MOBILE: 600, // md breakpoint
+  SIDEBAR_OVERLAY: 1000 // width under which sidebar becomes overlay
 };
 
 // ----------------------

--- a/source/App.vue
+++ b/source/App.vue
@@ -329,10 +329,8 @@ async function handleCategoryReorder(reorderedCategories) {
     await handleAsyncAction(updateCategory, category);
   }
   
-  // Force refresh of categories after a short delay to ensure consistency
-  setTimeout(async () => {
-    await getCategories();
-  }, 100);
+  // Refresh categories after all updates to ensure consistency
+  await getCategories();
 }
 
 // ----------------------

--- a/source/App.vue
+++ b/source/App.vue
@@ -404,6 +404,7 @@ watch([isSidebarOpen, isMobileViewport, isSmallDesktop], () => {
     document.body.style.overflow = '';
   }
 });
+
 </script>
 
 <style>

--- a/source/components/AddCategoryButton.vue
+++ b/source/components/AddCategoryButton.vue
@@ -24,5 +24,11 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Emits
 defineEmits(['click']);
+
 </script>

--- a/source/components/AddItemButton.vue
+++ b/source/components/AddItemButton.vue
@@ -34,11 +34,26 @@ Created: 2025-09-19
 <script setup>
 import { ref } from 'vue';
 
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props
 const props = defineProps({
-  categoryCompleted: { type: Boolean, default: false }
+  categoryCompleted: { 
+    type: Boolean, 
+    default: false 
+  }
 });
 
+// Emits
 defineEmits(['click']);
 
+// ----------------------
+// States
+// ----------------------
+
+// Hover state
 const isHovered = ref(false);
+
 </script>

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -12,7 +12,7 @@ Created: 2025-09-19
 <template>
   <div
     :class="[
-      'p-3 rounded-xl shadow-md transition-shadow duration-200 group',
+      'p-3 rounded-xl shadow-md transition-all duration-200 group',
       isCompleted ? 'bg-green-50 hover:shadow-lg' : 'bg-white hover:shadow-lg'
     ]"
   >
@@ -59,15 +59,40 @@ Created: 2025-09-19
 
     <!-- Items List -->
     <div class="space-y-0.5">
-      <Item
-        v-for="item in itemsForCategory"
-        :key="item.id"
-        :item="item"
-        :newly-created-item-id="newlyCreatedItemId"
-        :category-completed="isCompleted"
-        @update:item="$emit('update:item', $event)"
-        @delete="$emit('delete:item', item.id)"
-      />
+      <draggable
+        v-model="draggableItems"
+        :group="{ 
+          name: 'items', 
+          pull: true, 
+          put: function(to, from, dragEl, evt) {
+            // Only allow items to be dropped in item containers, not categories
+            return from.options.group.name === 'items';
+          }
+        }"
+        item-key="id"
+        :animation="200"
+        :ghost-class="'ghost-item'"
+        :chosen-class="'chosen-item'"
+        :drag-class="'drag-item'"
+        @start="onDragStart"
+        @end="onDragEnd"
+        @add="onItemAdd"
+        @remove="onItemRemove"
+        @update="onItemUpdate"
+      >
+        <template #item="{ element: item }">
+          <div :key="item.id" :data-item-id="item.id">
+            <Item
+              :item="item"
+              :newly-created-item-id="newlyCreatedItemId"
+              :category-completed="isCompleted"
+              :is-dragging="draggingItemId === item.id"
+              @update:item="$emit('update:item', $event)"
+              @delete="$emit('delete:item', item.id)"
+            />
+          </div>
+        </template>
+      </draggable>
 
       <AddItemButton
         class="px-2 py-1 text-sm"
@@ -80,12 +105,18 @@ Created: 2025-09-19
 
 <script setup>
 import { computed, nextTick, ref, watch } from 'vue';
+import draggable from 'vuedraggable';
 import { Category } from '../models/Category';
 import AddItemButton from './AddItemButton.vue';
 import Item from './Item.vue';
 import OverflowMenu from './OverflowMenu.vue';
 import ProgressBar from './ProgressBar.vue';
 
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props validation
 const props = defineProps({
   category: {
     type: Object,
@@ -117,25 +148,78 @@ const emit = defineEmits([
   'delete:item',
   'create:item',
   'update:category',
-  'delete:category'
+  'delete:category',
+  'move:item'
 ]);
+
+// ----------------------
+// States
+// ----------------------
 
 // Editing state
 const isEditing = ref(false);
 const editedName = ref('');
 const editInput = ref(null);
 
+// Drag state
+const draggingItemId = ref(null);
+
+// ----------------------
+// Computed
+// ----------------------
+
 const itemsForCategory = computed(() => {
   const filteredItems = props.items.filter(item => item.categoryId === props.category.id);
-  return filteredItems;
+  // Sort by order field to maintain correct sequence
+  return filteredItems.sort((a, b) => (a.order || 0) - (b.order || 0));
 });
 
-// Whether the category is completed: has items and all are packed
+const draggableItems = computed({
+  get() {
+    return itemsForCategory.value;
+  },
+  set(newItems) {
+    // When vuedraggable updates the array, emit the reorder event
+    // Check if this is a cross-category move (new item added)
+    const currentItemIds = new Set(itemsForCategory.value.map(i => i.id));
+    const newItemIds = new Set(newItems.map(i => i.id));
+    const addedItems = newItems.filter(item => !currentItemIds.has(item.id));
+    const removedItems = itemsForCategory.value.filter(item => !newItemIds.has(item.id));
+    
+    if (addedItems.length > 0) {
+      // Don't handle cross-category moves here, let onItemAdd handle them
+      return;
+    }
+    
+    if (removedItems.length > 0) {
+      // Don't handle cross-category moves here, let onItemRemove handle them
+      return;
+    }
+    
+    // This is a same-category reorder
+    const itemsWithNewOrder = newItems.map((item, index) => ({
+      ...item,
+      order: index
+    }));
+    
+    emit('move:item', {
+      items: itemsWithNewOrder,
+      categoryId: props.category.id,
+      type: 'reorder'
+    });
+  }
+});
+
+// Completing state
 const isCompleted = computed(() => {
   const items = itemsForCategory.value;
   if (!items.length) return false;
   return items.every(i => i.isPacked);
 });
+
+// ----------------------
+// Editing functions
+// ----------------------
 
 // Start editing mode
 async function startEdit() {
@@ -149,7 +233,7 @@ async function startEdit() {
   }
 }
 
-// Save edited name
+// Save edited values
 function saveEdit() {
   const hasNameChanged = editedName.value.trim() && editedName.value !== props.category.name;
 
@@ -169,10 +253,103 @@ function cancelEdit() {
   editedName.value = props.category.name;
 }
 
+// ----------------------
+// Category management
+// ----------------------
+
 // Handle delete action
 function handleDelete() {
   emit('delete:category', props.category.id);
 }
+
+// ----------------------
+// Drag and drop handlers (vuedraggable events)
+// ----------------------
+
+// Track which item is being dragged
+function onDragStart(evt) {
+  const item = evt.item.querySelector('[data-item-id]');
+  if (item) {
+    draggingItemId.value = item.dataset.itemId;
+  }
+}
+
+// Clean up drag state when drag ends
+function onDragEnd(evt) {
+  draggingItemId.value = null;
+}
+
+// Handle same-category reorder (handled by draggableItems setter instead)
+function onItemUpdate(evt) {
+  // This event is now handled by the draggableItems setter
+}
+
+// Handle item moved from another category to this category
+function onItemAdd(evt) {
+  // Handle item moved from another category
+  const newElement = evt.item;
+  const itemId = newElement.getAttribute('data-item-id');
+  
+  if (itemId) {
+    const item = props.items.find(i => i.id === itemId);
+    if (item && item.categoryId !== props.category.id) {
+      
+      // Get current items in this category (excluding the newly added item)
+      const currentCategoryItems = itemsForCategory.value.filter(i => i.id !== itemId);
+      
+      // Create new item with updated category and order
+      const updatedItem = {
+        ...item,
+        categoryId: props.category.id,
+        order: evt.newIndex
+      };
+      
+      // Update order of existing items that come after the insertion point
+      const reorderedItems = currentCategoryItems.map((existingItem, index) => {
+        let newOrder = index;
+        if (index >= evt.newIndex) {
+          newOrder = index + 1; // Shift items down
+        }
+        return {
+          ...existingItem,
+          order: newOrder
+        };
+      });
+      
+      emit('move:item', {
+        item: updatedItem,
+        reorderedItems: reorderedItems,
+        newCategoryId: props.category.id,
+        oldCategoryId: item.categoryId,
+        newIndex: evt.newIndex,
+        type: 'move'
+      });
+    }
+  }
+}
+
+// Handle item moved from this category to another category
+function onItemRemove(evt) {
+  // After item removal, reorder the remaining items
+  setTimeout(() => {
+    const remainingItems = itemsForCategory.value.map((item, index) => ({
+      ...item,
+      order: index
+    }));
+    
+    if (remainingItems.length > 0) {
+      emit('move:item', {
+        items: remainingItems,
+        categoryId: props.category.id,
+        type: 'reorder'
+      });
+    }
+  }, 10);
+}
+
+// ----------------------
+// Watchers
+// ----------------------
 
 // Watch for newly created category and auto-start edit
 watch(() => props.newlyCreatedCategoryId, (newId) => {
@@ -183,3 +360,56 @@ watch(() => props.newlyCreatedCategoryId, (newId) => {
   }
 });
 </script>
+
+<style scoped>
+/* Drag and drop styles */
+.ghost-item {
+  opacity: 0.3;
+  background: #f3f4f6;
+  border: 2px dashed #9ca3af;
+}
+
+.chosen-item {
+  cursor: grabbing !important;
+}
+
+.drag-item {
+  opacity: 0.5;
+  transform: scale(1.05);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+}
+
+/* Drag handle */
+.drag-handle {
+  cursor: grab;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+/* Drop zone visual feedback */
+.bg-blue-50 {
+  background-color: rgb(239 246 255);
+}
+
+.border-dashed {
+  border-style: dashed;
+}
+
+/* Smooth transitions */
+.transition-all {
+  transition-property: all;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Success flash animation */
+@keyframes flash-success {
+  0%, 100% { border-color: transparent; }
+  50% { border-color: #10b981; }
+}
+
+.flash-success {
+  animation: flash-success 0.6s ease-in-out;
+}
+</style>

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -114,7 +114,7 @@ Created: 2025-09-19
         :chosen-class="'chosen-category'"
         :drag-class="'drag-category'"
         :class="[
-          'flex flex-wrap gap-2',
+          'categories-masonry',
           isDraggingCategory ? 'dragging' : ''
         ]"
         @start="onCategoryDragStart"
@@ -424,39 +424,49 @@ watch(() => props.newlyCreatedChecklistId, (newId) => {
   z-index: 1000;
 }
 
-/* Category item responsive width with gap calculation */
+/* Masonry layout using CSS columns */
+.categories-masonry {
+  column-count: 1;
+  column-gap: 0.5rem; /* gap-2 */
+}
+
+@media (min-width: 600px) {
+  .categories-masonry {
+    column-count: 2;
+  }
+}
+
+@media (min-width: 840px) {
+  .categories-masonry {
+    column-count: 3;
+  }
+}
+
+@media (min-width: 1280px) {
+  .categories-masonry {
+    column-count: 4;
+  }
+}
+
+/* Prevent categories from breaking across columns */
 .category-item {
+  break-inside: avoid;
+  page-break-inside: avoid; /* For older browsers */
+  margin-bottom: 0.5rem; /* gap-2 */
+  display: inline-block;
   width: 100%;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-@media (min-width: 640px) {
-  .category-item {
-    width: calc(50% - 0.25rem); /* 2 columns, accounting for gap-2 (0.5rem) */
-  }
-}
-
-@media (min-width: 768px) {
-  .category-item {
-    width: calc(33.333333% - 0.333rem); /* 3 columns */
-  }
-}
-
-@media (min-width: 1024px) {
-  .category-item {
-    width: calc(25% - 0.375rem); /* 4 columns */
-  }
-}
-
-/* Flex layout preservation during drag */
-.flex.dragging > * {
+/* Layout preservation during drag */
+.categories-masonry.dragging > * {
   transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
               opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   will-change: transform, opacity;
 }
 
-/* Smooth transitions for flex items */
-.flex > * {
+/* Smooth transitions for masonry items */
+.categories-masonry > * {
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -196,6 +196,7 @@ const props = defineProps({
   }
 });
 
+// Emits
 const emit = defineEmits([
   'update:checklist',
   'delete:checklist',
@@ -230,12 +231,12 @@ const isDraggingCategory = ref(false);
 // Computed
 // ----------------------
 
-// Sorted categories for display
+// Sorted categories for this checklist (sorted by order)
 const sortedCategories = computed(() => {
   return [...props.categories].sort((a, b) => (a.order || 0) - (b.order || 0));
 });
 
-// Writable computed for draggable v-model
+// Draggable categories (two-way binding with vuedraggable)
 const draggableCategories = computed({
   get() {
     return sortedCategories.value;
@@ -285,7 +286,7 @@ async function startEdit() {
   }
 }
 
-// Save edited values
+// Save edited checklist
 function saveEdit() {
   const hasDestinationChanged = editedDestination.value.trim() !== props.checklist.destination;
   const hasStartDateChanged = editedStartDate.value !== props.checklist.startDate;
@@ -402,6 +403,7 @@ watch(() => props.newlyCreatedChecklistId, (newId) => {
     });
   }
 });
+
 </script>
 
 <style scoped>

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -97,33 +97,70 @@ Created: 2025-09-19
     </div>
 
     <!-- Categories Grid -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-2">
-      <Category
-        v-for="category in categories"
-        :key="category.id"
-        :category="category"
-        :items="items"
-        :newly-created-item-id="newlyCreatedItemId"
-        :newly-created-category-id="newlyCreatedCategoryId"
-        @update:item="$emit('update:item', $event)"
-        @delete:item="$emit('delete:item', $event)"
-        @create:item="$emit('create:item', $event)"
-        @update:category="$emit('update:category', $event)"
-        @delete:category="$emit('delete:category', $event)"
-      />
+    <div>
+      <draggable
+        v-model="draggableCategories"
+        :group="{ 
+          name: 'categories', 
+          pull: true, 
+          put: function(to, from, dragEl, evt) {
+            // Only allow categories to be dropped in the category container
+            return from.options.group.name === 'categories';
+          }
+        }"
+        item-key="id"
+        :animation="200"
+        :ghost-class="'ghost-category'"
+        :chosen-class="'chosen-category'"
+        :drag-class="'drag-category'"
+        :class="[
+          'flex flex-wrap gap-2',
+          isDraggingCategory ? 'dragging' : ''
+        ]"
+        @start="onCategoryDragStart"
+        @end="onCategoryDragEnd"
+        @update="onCategoryUpdate"
+      >
+        <template #item="{ element: category }">
+          <div class="category-item">
+            <Category
+              :key="category.id"
+              :data-category-id="category.id"
+              :category="category"
+              :items="items"
+              :newly-created-item-id="newlyCreatedItemId"
+              :newly-created-category-id="newlyCreatedCategoryId"
+              @update:item="$emit('update:item', $event)"
+              @delete:item="$emit('delete:item', $event)"
+              @create:item="$emit('create:item', $event)"
+              @update:category="$emit('update:category', $event)"
+              @delete:category="$emit('delete:category', $event)"
+              @move:item="handleItemMove"
+            />
+          </div>
+        </template>
+      </draggable>
 
-      <AddCategoryButton @click="$emit('create:category')" />
+      <div class="category-item">
+        <AddCategoryButton @click="$emit('create:category')" />
+      </div>
     </div>
   </div>
 </template>
 
 <script setup>
-import { nextTick, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
+import draggable from 'vuedraggable';
 import AddCategoryButton from './AddCategoryButton.vue';
 import Category from './Category.vue';
 import OverflowMenu from './OverflowMenu.vue';
 import ProgressBar from './ProgressBar.vue';
 
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props validation
 const props = defineProps({
   checklist: {
     type: Object,
@@ -167,8 +204,14 @@ const emit = defineEmits([
   'create:item',
   'update:category',
   'delete:category',
-  'create:category'
+  'create:category',
+  'reorder:categories',
+  'move:item'
 ]);
+
+// ----------------------
+// States
+// ----------------------
 
 // Editing state
 const isEditing = ref(false);
@@ -179,6 +222,39 @@ const destinationInput = ref(null);
 const startDateInput = ref(null);
 const endDateInput = ref(null);
 
+// Drag state
+const draggingCategoryId = ref(null);
+const isDraggingCategory = ref(false);
+
+// ----------------------
+// Computed
+// ----------------------
+
+// Sorted categories for display
+const sortedCategories = computed(() => {
+  return [...props.categories].sort((a, b) => (a.order || 0) - (b.order || 0));
+});
+
+// Writable computed for draggable v-model
+const draggableCategories = computed({
+  get() {
+    return sortedCategories.value;
+  },
+  set(newCategories) {
+    // When vuedraggable updates the array, emit the reorder event
+    const categoriesWithNewOrder = newCategories.map((category, index) => ({
+      ...category,
+      order: index
+    }));
+    
+    emit('reorder:categories', categoriesWithNewOrder);
+  }
+});
+
+// ----------------------
+// Editing functions
+// ----------------------
+
 // Handle edit blur - only save if focus is moving outside edit area
 function handleEditBlur(event) {
   // Use a small timeout to allow focus to move to the other input
@@ -186,8 +262,8 @@ function handleEditBlur(event) {
     // Check if focus is still within editing elements
     const activeElement = document.activeElement;
     const isStillEditing = activeElement === destinationInput.value ||
-                          activeElement === startDateInput.value ||
-                          activeElement === endDateInput.value;
+                           activeElement === startDateInput.value ||
+                           activeElement === endDateInput.value;
 
     if (!isStillEditing && isEditing.value) {
       saveEdit();
@@ -209,7 +285,7 @@ async function startEdit() {
   }
 }
 
-// Save edited checklist
+// Save edited values
 function saveEdit() {
   const hasDestinationChanged = editedDestination.value.trim() !== props.checklist.destination;
   const hasStartDateChanged = editedStartDate.value !== props.checklist.startDate;
@@ -235,20 +311,49 @@ function cancelEdit() {
   editedEndDate.value = props.checklist.endDate;
 }
 
+// ----------------------
+// Checklist management
+// ----------------------
+
 // Handle delete action
 function handleDelete() {
   emit('delete:checklist', props.checklist.id);
 }
 
-// Watch for newly created checklists and auto-start edit
-watch(() => props.newlyCreatedChecklistId, (newId) => {
-  if (newId === props.checklist.id) {
-    nextTick(() => {
-      startEdit();
-    });
-  }
-});
+// ----------------------
+// Drag and drop handlers (vuedraggable events)
+// ----------------------
 
+// Track which category is being dragged
+function onCategoryDragStart(evt) {
+  const categoryElement = evt.item.querySelector('[data-category-id]') || evt.item;
+  if (categoryElement.dataset.categoryId) {
+    draggingCategoryId.value = categoryElement.dataset.categoryId;
+  }
+  isDraggingCategory.value = true;
+}
+
+// Clean up drag state when drag ends
+function onCategoryDragEnd(evt) {
+  draggingCategoryId.value = null;
+  isDraggingCategory.value = false;
+}
+
+// Handle category reorder (handled by draggableCategories setter instead)
+function onCategoryUpdate(evt) {
+  // This event is now handled by the draggableCategories setter
+}
+
+// Handle item movement between categories
+function handleItemMove(moveData) {
+  emit('move:item', moveData);
+}
+
+// ----------------------
+// Helpers
+// ----------------------
+
+// Format date range for display
 function formatDateRange(startDate, endDate) {
   // Parse YYYY-MM-DD strings into local Date objects to avoid timezone shifts
   function parseLocalDate(dateStr) {
@@ -284,4 +389,88 @@ function formatDateRange(startDate, endDate) {
     year: 'numeric'
   })}`;
 }
+
+// ----------------------
+// Watchers
+// ----------------------
+
+// Watch for newly created checklists and auto-start edit
+watch(() => props.newlyCreatedChecklistId, (newId) => {
+  if (newId === props.checklist.id) {
+    nextTick(() => {
+      startEdit();
+    });
+  }
+});
 </script>
+
+<style scoped>
+/* Category drag and drop styles */
+.ghost-category {
+  opacity: 0.3;
+  background: #f3f4f6;
+  border: 2px dashed #9ca3af;
+  border-radius: 0.75rem;
+}
+
+.chosen-category {
+  cursor: grabbing !important;
+}
+
+.drag-category {
+  opacity: 0.5;
+  transform: scale(1.02);
+  box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  z-index: 1000;
+}
+
+/* Category item responsive width with gap calculation */
+.category-item {
+  width: 100%;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+@media (min-width: 640px) {
+  .category-item {
+    width: calc(50% - 0.25rem); /* 2 columns, accounting for gap-2 (0.5rem) */
+  }
+}
+
+@media (min-width: 768px) {
+  .category-item {
+    width: calc(33.333333% - 0.333rem); /* 3 columns */
+  }
+}
+
+@media (min-width: 1024px) {
+  .category-item {
+    width: calc(25% - 0.375rem); /* 4 columns */
+  }
+}
+
+/* Flex layout preservation during drag */
+.flex.dragging > * {
+  transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+              opacity 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform, opacity;
+}
+
+/* Smooth transitions for flex items */
+.flex > * {
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Success animation */
+@keyframes flash-success {
+  0%, 100% { 
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  }
+  50% { 
+    box-shadow: 0 4px 6px -1px rgba(16, 185, 129, 0.3), 0 2px 4px -1px rgba(16, 185, 129, 0.2);
+  }
+}
+
+.flash-success {
+  animation: flash-success 0.6s ease-in-out;
+}
+</style>

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -107,7 +107,7 @@ import OverflowMenu from './OverflowMenu.vue';
 // Props & Emits
 // ----------------------
 
-// Props validation
+// Props
 const props = defineProps({
   item: {
     type: Object,
@@ -137,9 +137,10 @@ const props = defineProps({
   }
 });
 
+// Emits
 const emit = defineEmits([
   'update:item',
-  'delete'
+  'delete:item'
 ]);
 
 // ----------------------
@@ -239,7 +240,7 @@ function cancelEdit() {
 
 // Handle delete action
 function handleDelete() {
-  emit('delete');
+  emit('delete:item', props.item.id);
 }
 
 // ----------------------

--- a/source/components/OverflowMenu.vue
+++ b/source/components/OverflowMenu.vue
@@ -56,6 +56,11 @@ Created: 2025-09-19
 <script setup>
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props
 const props = defineProps({
   itemId: {
     type: String,
@@ -81,11 +86,25 @@ const props = defineProps({
   }
 });
 
+// Emits
 const emit = defineEmits(['edit', 'delete']);
 
-const showMenu = ref(false);
+// ----------------------
+// States
+// ----------------------
 
-// Computed classes based on props
+// Menu state
+const showMenu = ref(false);
+const dropdownStyle = ref({});
+const dropdownRef = ref(null);
+const buttonRef = ref(null);
+const root = ref(null);
+
+// ----------------------
+// Computed
+// ----------------------
+
+// Button visibility based on props and menu state
 const buttonClass = computed(() => {
   const baseClass = 'p-1 flex items-center justify-center text-secondary rounded-md transition-opacity duration-200 hover:bg-gray-200 hover:text-primary';
 
@@ -103,28 +122,30 @@ const buttonClass = computed(() => {
   return `${baseClass} opacity-0`;
 });
 
-// Dropdown styling: let width size to content, cap max width
+// Dropdown styling
 const dropdownClass = computed(() =>
   `mt-1 bg-white border border-gray-200 rounded-md shadow-lg z-50 w-auto max-w-xs`
 );
 
+// SVG icon size based on menu type
 const svgClass = computed(() => {
-  // category uses larger icon
   return props.menuType === 'item' ? 'w-5 h-5' : 'w-6 h-6';
 });
 
-// Dropdown positioning
-const dropdownStyle = ref({});
-const dropdownRef = ref(null);
-const buttonRef = ref(null);
+// ----------------------
+// Menu positioning
+// ----------------------
+
+// Position dropdown relative to button
 function positionDropdown() {
   if (!buttonRef.value || !dropdownRef.value) return;
   const btnRect = buttonRef.value.getBoundingClientRect();
   const ddRect = dropdownRef.value.getBoundingClientRect();
-  // Align dropdown right edge with the button's right edge so it appears directly under the icon
+  
+  // Align dropdown right edge with the button's right edge
   let left = btnRect.right - ddRect.width;
 
-  // clamp within viewport with 8px padding
+  // Clamp within viewport with 8px padding
   const minPadding = 8;
   const maxLeft = window.innerWidth - ddRect.width - minPadding;
   if (left < minPadding) left = minPadding;
@@ -140,10 +161,15 @@ function positionDropdown() {
   };
 }
 
+// ----------------------
+// Menu actions
+// ----------------------
+
 // Toggle dropdown menu
 function toggleMenu() {
   const willOpen = !showMenu.value;
   showMenu.value = willOpen;
+  
   if (willOpen) {
     // First position dropdown off-screen to measure, then position correctly
     dropdownStyle.value = { position: 'fixed', left: '-9999px', top: '-9999px', zIndex: 9999 };
@@ -177,13 +203,16 @@ function handleDelete() {
   emit('delete');
 }
 
+// ----------------------
+// Event handlers
+// ----------------------
+
 // Close menu when clicking outside
-const root = ref(null);
 function closeMenu(event) {
-  // If click is outside both the button root and the fixed dropdown, close the menu
   const target = event.target;
   const clickedInsideRoot = root.value && root.value.contains(target);
   const clickedInsideDropdown = dropdownRef.value && dropdownRef.value.contains(target);
+  
   if (!clickedInsideRoot && !clickedInsideDropdown) {
     showMenu.value = false;
   }
@@ -194,25 +223,32 @@ function closeMenuOnScroll() {
   showMenu.value = false;
 }
 
-// Close when another menu opens (any type)
+// Close when another menu opens
 function closeWhenOtherOpens(e) {
   const detail = e?.detail || {};
   const otherId = detail.id;
+  
   if (otherId && otherId !== props.itemId) {
     showMenu.value = false;
   }
 }
 
-// Add event listeners
+// ----------------------
+// Lifecycle Hooks
+// ----------------------
+
+// Set up event listeners
 onMounted(() => {
   document.addEventListener('click', closeMenu);
   window.addEventListener('scroll', closeMenuOnScroll, true);
   window.addEventListener('overflow-menu-open', closeWhenOtherOpens);
 });
 
+// Clean up event listeners
 onUnmounted(() => {
   document.removeEventListener('click', closeMenu);
   window.removeEventListener('scroll', closeMenuOnScroll, true);
   window.removeEventListener('overflow-menu-open', closeWhenOtherOpens);
 });
+
 </script>

--- a/source/components/ProgressBar.vue
+++ b/source/components/ProgressBar.vue
@@ -28,6 +28,11 @@ Created: 2025-09-19
 import { computed } from 'vue';
 import { THEME_COLORS } from '../utils/constants';
 
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props
 const props = defineProps({
   total: {
     type: Number,
@@ -39,16 +44,28 @@ const props = defineProps({
   }
 });
 
+// ----------------------
+// Computed
+// ----------------------
+
+// Calculate completion percentage
 const percentage = computed(() => {
   if (props.total === 0) return 0;
   return Math.round((props.completed / props.total) * 100);
 });
 
+// Display text for progress
 const text = computed(() => {
   return `${props.completed} / ${props.total}`;
 });
 
+// ----------------------
+// Constants
+// ----------------------
+
+// Theme colors
 const progressColor = THEME_COLORS.PRIMARY;
 const textColor = THEME_COLORS.TEXT_PRIMARY;
 const backgroundColor = THEME_COLORS.SECONDARY;
+
 </script>

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -123,6 +123,11 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props
 defineProps({
   isExpanded: {
     type: Boolean,
@@ -146,5 +151,7 @@ defineProps({
   }
 });
 
+// Emits
 defineEmits(['toggle-sidebar', 'create-checklist', 'select-checklist']);
+
 </script>

--- a/source/components/Topbar.vue
+++ b/source/components/Topbar.vue
@@ -36,6 +36,11 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Props & Emits
+// ----------------------
+
+// Props
 const props = defineProps({
   title: {
     type: String,
@@ -43,5 +48,7 @@ const props = defineProps({
   }
 });
 
+// Emits
 defineEmits(['toggle', 'new']);
+
 </script>

--- a/source/composables/usePackingLists.js
+++ b/source/composables/usePackingLists.js
@@ -173,7 +173,7 @@ export function usePackingLists() {
       () => dataService.getCategories(selectedChecklistId.value),
       'Error getting categories'
     );
-    categories.value = result || [];
+    categories.value = (result || []).sort((a, b) => (a.order || 0) - (b.order || 0));
     return categories.value;
   }
 
@@ -223,7 +223,18 @@ export function usePackingLists() {
       () => dataService.getItems(selectedChecklistId.value),
       'Error getting items'
     );
-    items.value = result || [];
+    items.value = (result || []).sort((a, b) => {
+      // First sort by category order, then by item order within category
+      const catA = categories.value.find(c => c.id === a.categoryId);
+      const catB = categories.value.find(c => c.id === b.categoryId);
+      const catOrderA = catA ? catA.order || 0 : 0;
+      const catOrderB = catB ? catB.order || 0 : 0;
+      
+      if (catOrderA !== catOrderB) {
+        return catOrderA - catOrderB;
+      }
+      return (a.order || 0) - (b.order || 0);
+    });
     return items.value;
   }
 

--- a/source/models/Category.js
+++ b/source/models/Category.js
@@ -19,11 +19,13 @@ export class Category {
   constructor({
     id = generateSecureId('category-'),
     name = '',
-    checklistId = null
+    checklistId = null,
+    order = 0
   } = {}) {
     this.id = id;
     this.name = this.validateName(name);
     this.checklistId = checklistId;
+    this.order = Number(order) || 0;
   }
 
   /**
@@ -59,7 +61,8 @@ export class Category {
     return {
       id: this.id,
       name: this.name,
-      checklistId: this.checklistId
+      checklistId: this.checklistId,
+      order: this.order
     };
   }
 }

--- a/source/models/Item.js
+++ b/source/models/Item.js
@@ -22,7 +22,8 @@ export class Item {
     quantity = 1,
     categoryId = null,
     isPacked = false,
-    checklistId = null
+    checklistId = null,
+    order = 0
   } = {}) {
     this.id = id;
     this.name = this.validateName(name);
@@ -30,6 +31,7 @@ export class Item {
     this.categoryId = categoryId;
     this.isPacked = Boolean(isPacked);
     this.checklistId = checklistId;
+    this.order = Number(order) || 0;
   }
 
   /**
@@ -88,7 +90,8 @@ export class Item {
       quantity: this.quantity,
       categoryId: this.categoryId,
       isPacked: this.isPacked,
-      checklistId: this.checklistId
+      checklistId: this.checklistId,
+      order: this.order
     };
   }
 

--- a/source/services/localStorageService.js
+++ b/source/services/localStorageService.js
@@ -93,7 +93,7 @@ export class LocalStorageService extends DataService {
     }
   }
 
-  /**
+    /**
    * Create default categories and items for a new checklist
    * @param {string} checklistId - The checklist ID
    * @returns {Object} Object containing { categories: Array, items: Array }
@@ -102,20 +102,25 @@ export class LocalStorageService extends DataService {
     // Extract unique category names from default items
     const categoryNames = [...new Set(defaultItems.map(item => item.category))];
     
-    // Create Category objects
-    const categories = categoryNames.map(name => new Category({ name, checklistId }));
+    // Create Category objects with order
+    const categories = categoryNames.map((name, index) => new Category({ 
+      name, 
+      checklistId,
+      order: index 
+    }));
     
     // Create a mapping from category name to category ID
     const categoryMap = Object.fromEntries(categories.map(cat => [cat.name, cat.id]));
     
-    // Create Item objects mapped to the correct categories
-    const items = defaultItems.map(item => new Item({
+    // Create Item objects mapped to the correct categories with order
+    const items = defaultItems.map((item, index) => new Item({
       id: generateSecureId('item-'),
       name: item.name,
       quantity: item.quantity,
       categoryId: categoryMap[item.category],
       isPacked: false,
-      checklistId: checklistId
+      checklistId: checklistId,
+      order: index
     }));
     
     return { categories, items };


### PR DESCRIPTION
This pull request adds drag-and-drop support to reorder items within a category, move items between categories, and reorder categories. Orders are persisted and progress updates immediately.

Key changes:

Components / UI:
- Add vuedraggable handlers in Category.vue and Checklist.vue.
- Visual feedback: ghost / chosen / drag classes and ~200ms animations.
  - ghost: placeholder at the drop location (semi-transparent / dashed) to indicate insertion point.
  - chosen: the element shown while dragging (and the element marked as grabbed).
  - drag: active dragged element styling (scale, shadow, opacity) for clear affordance.

Logic & persistence:
- Update order and category via usePackingLists.js, persist changes through localStorageService.
- Ensure lists are refreshed after updates so UI and progress stay consistent.

Documentation:
- Update specs product-spec.md to document behavior and verification steps.