### PR TITLE
feat: Add multi-language support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "vue": "^3.5.21",
+        "vue-i18n": "^9.14.5",
         "vuedraggable": "^4.1.0"
       },
       "devDependencies": {
@@ -426,6 +427,47 @@
         "node": ">=12"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.14.5.tgz",
+      "integrity": "sha512-5ah5FqZG4pOoHjkvs8mjtv+gPKYU0zCISaYNjBNNqYiaITxW8ZtVih3GS/oTOqN8d9/mDLyrjD46GBApNxmlsA==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.14.5",
+        "@intlify/shared": "9.14.5"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.14.5.tgz",
+      "integrity": "sha512-IHzgEu61/YIpQV5Pc3aRWScDcnFKWvQA9kigcINcCBXN8mbW+vk9SK+lDxA6STzKQsVJxUPg9ACC52pKKo3SVQ==",
+      "dependencies": {
+        "@intlify/shared": "9.14.5",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.14.5.tgz",
+      "integrity": "sha512-9gB+E53BYuAEMhbCAxVgG38EZrk59sxBtv3jSizNL2hEWlgjBjAw1AwpLHtNaeda12pe6W20OGEa0TwuMSRbyQ==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -580,6 +622,11 @@
         "@vue/compiler-dom": "3.5.21",
         "@vue/shared": "3.5.21"
       }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
+      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g=="
     },
     "node_modules/@vue/reactivity": {
       "version": "3.5.21",
@@ -2103,6 +2150,25 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vue-i18n": {
+      "version": "9.14.5",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.14.5.tgz",
+      "integrity": "sha512-0jQ9Em3ymWngyiIkj0+c/k7WgaPO+TNzjKSNq9BvBQaKJECqn9cd9fL4tkDhB5G1QBskGl9YxxbDAhgbFtpe2g==",
+      "dependencies": {
+        "@intlify/core-base": "9.14.5",
+        "@intlify/shared": "9.14.5",
+        "@vue/devtools-api": "^6.5.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/kazupon"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
       }
     },
     "node_modules/vuedraggable": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "vue": "^3.5.21",
+    "vue-i18n": "^9.14.5",
     "vuedraggable": "^4.1.0"
   },
   "devDependencies": {

--- a/product-spec.md
+++ b/product-spec.md
@@ -146,6 +146,24 @@ Checklist, Category, and Item are the three core data entities of the app. Below
   - Desktop refresh: `Sidebar` collapse state reflects `localStorage` value.
   - Masonry columns adjust at breakpoints; category cards don’t break across columns.
 
+#### Internationalization (i18n)
+- Purpose: Provide a multi-language interface so users can switch languages with immediate effect, and persist their preference.
+- Key features:
+  - Language switcher: Located in the Sidebar as a globe icon button with a dropdown menu.
+  - Supported languages: English (`en`), Traditional Chinese (`zh-TW`).
+  - Initial detection and fallback: Prefer the saved localStorage setting first; otherwise infer from the browser’s language; default fallback is English (`en`).
+  - Traditional Chinese variants mapping: Common variants (`zh`, `zh-Hant`, `zh-TW`, `zh-HK`, `zh-MO`) are normalized to `zh-TW`.
+  - Accessibility strings: Assistive texts like button `aria-label`/`title` switch with the current locale as well.
+  - String fallback: Missing keys fall back to English via `fallbackLocale: 'en'`.
+- Flow:
+  - User clicks the language button in the Sidebar and selects EN / Traditional Chinese; UI text updates immediately and the preference is stored (localStorage key: `user-locale`).
+- Validation:
+  - Interaction: After switching language from the Sidebar, buttons, titles, menus, and `aria-label/title` update immediately.
+  - Persistence: After a refresh, the previously selected language remains in effect (read from localStorage `user-locale`).
+  - Detection: With no prior preference, infer from the browser language; non-`zh` series defaults to English; `zh/zh-Hant/zh-TW/zh-HK/zh-MO` are mapped to `zh-TW`.
+  - Fallback: Temporarily remove a translation key to verify the app falls back to English (ensuring `fallbackLocale` takes effect).
+
+
 #### Drag and Drop
 - Purpose: Quickly reorder and reorganize categories/items by dragging, keeping orders consistent with minimal effort.
 - Key features:

--- a/product-spec.md
+++ b/product-spec.md
@@ -206,13 +206,13 @@ Checklist, Category, and Item are the three core data entities of the app. Below
 ## 5. File Structure
 ```
 packing-list/
-├── index.html                          # Entry HTML
-├── LICENSE                             # License terms
-├── package.json                        # Dependencies and scripts
-├── postcss.config.js                   # PostCSS config
-├── tailwind.config.js                  # Tailwind CSS config
-├── vite.config.js                      # Vite build config
-└── source/                             # Application source
+├── index.html                        # Entry HTML
+├── LICENSE                           # License terms
+├── package.json                      # Dependencies and scripts
+├── postcss.config.js                 # PostCSS config
+├── tailwind.config.js                # Tailwind CSS config
+├── vite.config.js                    # Vite build config
+└── source/                           # Application source
   ├── App.vue                         # Root component
   ├── index.css                       # Global styles and Tailwind imports
   ├── main.js                         # App entry point (createApp + mount)
@@ -228,8 +228,15 @@ packing-list/
   │   └── Topbar.vue                  # Top bar for mobile
   ├── composables/                    # Vue composables (state + logic)
   │   └── usePackingLists.js          # Core state and CRUD logic
+  ├── i18n/                           # i18n initialization and locale detection/persistence
+  │   └── index.js                    # create vue-i18n, locale mapping, localStorage read/write
+  ├── locales/                        # Translation files
+  │   ├── en.json                     # English strings
+  │   └── zh-TW.json                  # Traditional Chinese strings
   ├── data/                           # Static data
-  │   └── defaultItems.js             # Default items for new checklists
+  │   ├── defaultItems.js             # Default items loader (locale-aware)
+  │   ├── defaultItems_en.js          # English default items
+  │   └── defaultItems_zh-TW.js       # Traditional Chinese default items
   ├── models/                         # Domain models
   │   ├── Category.js                 # Category model
   │   ├── Checklist.js                # Checklist model
@@ -238,8 +245,8 @@ packing-list/
   │   ├── dataService.js              # Abstract data service interface
   │   └── localStorageService.js      # LocalStorage implementation
   └── utils/                          # Utilities
-    ├── constants.js                # App constants
-    └── helpers.js                  # Helper functions (e.g., ID generation)
+      ├── constants.js                # App constants
+      └── helpers.js                  # Helper functions (e.g., ID generation)
 ```
 
 ## 6. UI/UX Design

--- a/source/App.vue
+++ b/source/App.vue
@@ -94,18 +94,29 @@ Created: 2025-09-19
         v-else
         class="text-center text-secondary mt-20"
       >
-        Please create a new checklist first.
+        {{ $t('checklist.pleaseCreate') }}
       </div>
     </main>
   </div>
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed, onMounted, onUnmounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ChecklistComponent from './components/Checklist.vue';
 import Sidebar from './components/Sidebar.vue';
 import Topbar from './components/Topbar.vue';
 import { usePackingLists } from './composables/usePackingLists';
+
+// ----------------------
+// Internationalization (i18n)
+// ----------------------
+
+const { t } = useI18n();
 
 // ----------------------
 // Constants
@@ -121,7 +132,7 @@ const BREAKPOINTS = {
 };
 
 // ----------------------
-// Composable
+// Composables
 // ----------------------
 
 // Initialize packing lists composable
@@ -232,7 +243,7 @@ async function handleItemCreate(categoryId) {
   const maxOrder = categoryItems.length > 0 ? Math.max(...categoryItems.map(item => item.order || 0)) : -1;
   
   const newItemData = {
-    name: 'New Item',
+    name: t('item.defaultName'),
     quantity: 1,
     categoryId: categoryId,
     isPacked: false,
@@ -297,7 +308,7 @@ async function handleCategoryCreate() {
   const maxOrder = categories.value.length > 0 ? Math.max(...categories.value.map(cat => cat.order || 0)) : -1;
   
   const newCategoryData = {
-    name: 'New Category',
+    name: t('category.defaultName'),
     order: maxOrder + 1
   };
 
@@ -340,11 +351,11 @@ async function handleCategoryReorder(reorderedCategories) {
 // Create a new checklist
 async function handleChecklistCreate() {
   const newChecklistData = {
-    name: 'My New Checklist',
+    name: t('checklist.defaultName'),
   };
   const newChecklist = await handleAsyncAction(createChecklist, newChecklistData);
   if (newChecklist) {
-    currentChecklistId.value = newChecklist.id;
+    newlyCreatedChecklistId.value = newChecklist.id;
   }
 }
 
@@ -356,18 +367,18 @@ async function handleChecklistUpdate(checklist) {
 // Delete a checklist
 async function handleChecklistDelete(checklistId) {
   if (checklists.value.length <= 1) {
-    alert('Cannot delete the last checklist');
+    alert(t('checklist.cannotDeleteLast'));
     return;
   }
 
-  const confirmed = confirm('Are you sure you want to delete this checklist?');
+  const confirmed = confirm(t('checklist.deleteConfirm'));
   if (!confirmed) return;
 
   await handleAsyncAction(deleteChecklist, checklistId);
 
-  if (currentChecklistId.value === checklistId) {
+  if (selectedChecklistId.value === checklistId) {
     // Switch to first available checklist
-    currentChecklistId.value = checklists.value[0]?.id || null;
+    selectedChecklistId.value = checklists.value[0]?.id || null;
   }
 }
 

--- a/source/App.vue
+++ b/source/App.vue
@@ -10,10 +10,12 @@ Created: 2025-09-19
 -->
 
 <template>
-  <div :class="[
-    'min-h-screen text-slate-800',
-    isMobileViewport ? 'flex flex-col' : 'flex'
-  ]">
+  <div
+    :class="[
+      'min-h-screen text-slate-800',
+      isMobileViewport ? 'flex flex-col' : 'flex'
+    ]"
+  >
     <!-- Overlay for narrow screens when sidebar is open -->
     <div
       v-if="(isMobileViewport || (isSmallDesktop && isSidebarOpen)) && isSidebarOpen"
@@ -65,9 +67,10 @@ Created: 2025-09-19
     <!-- Main Content -->
     <main
       :class="[
-        'p-4 md:p-6 overflow-y-auto bg-gray-50 min-w-0 transition-filter duration-200',
-        isMobileViewport ? 'flex-1' : 'flex-1',
-        { 'filter blur-sm pointer-events-none': (isSidebarOpen && (isMobileViewport || isSmallDesktop)) }
+        'p-4 md:p-6 overflow-y-auto bg-gray-50 min-w-0 transition-filter duration-200 flex-1',
+        {
+          'filter blur-sm pointer-events-none': (isSidebarOpen && (isMobileViewport || isSmallDesktop))
+        }
       ]"
     >
       <div v-if="selectedChecklist">

--- a/source/components/AddCategoryButton.vue
+++ b/source/components/AddCategoryButton.vue
@@ -11,14 +11,26 @@ Created: 2025-09-19
 
 <template>
   <div
-    @click="$emit('click')"
     class="p-4 bg-white rounded-xl shadow-md transition-shadow duration-200 hover:shadow-lg cursor-pointer flex items-center justify-center min-h-[200px] border-2 border-dashed border-gray-300 hover:border-gray-400"
+    @click="$emit('click')"
   >
     <div class="text-center">
-      <svg class="w-8 h-8 text-secondary mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+      <svg
+        class="w-8 h-8 text-secondary mx-auto mb-2"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+        />
       </svg>
-      <span class="ml-2 text-base text-secondary group-hover:text-primary">{{ $t('category.newCategory') }}</span>
+      <span class="ml-2 text-base text-secondary group-hover:text-primary">
+        {{ $t('category.newCategory') }}
+      </span>
     </div>
   </div>
 </template>

--- a/source/components/AddCategoryButton.vue
+++ b/source/components/AddCategoryButton.vue
@@ -18,7 +18,7 @@ Created: 2025-09-19
       <svg class="w-8 h-8 text-secondary mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
       </svg>
-      <span class="ml-2 text-base text-secondary group-hover:text-primary">New Category</span>
+      <span class="ml-2 text-base text-secondary group-hover:text-primary">{{ $t('category.newCategory') }}</span>
     </div>
   </div>
 </template>

--- a/source/components/AddItemButton.vue
+++ b/source/components/AddItemButton.vue
@@ -27,11 +27,15 @@ Created: 2025-09-19
     </span>
 
     <!-- Label aligns with item name area -->
-    <span class="flex-grow text-base text-left" :class="isHovered ? 'text-primary' : 'text-secondary'">New Item</span>
+    <span class="flex-grow text-base text-left" :class="isHovered ? 'text-primary' : 'text-secondary'">{{ $t('item.newItem') }}</span>
   </button>
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { ref } from 'vue';
 
 // ----------------------

--- a/source/components/AddItemButton.vue
+++ b/source/components/AddItemButton.vue
@@ -11,23 +11,39 @@ Created: 2025-09-19
 
 <template>
   <button
+    class="flex items-center w-full py-0.5 px-2 rounded-md transition-colors duration-200 text-sm justify-start"
+    :class="[ categoryCompleted ? 'bg-green-50' : 'bg-white hover:bg-gray-100' ]"
     @click="$emit('click')"
     @mouseenter="isHovered = true"
     @mouseleave="isHovered = false"
-    :class="[
-      'flex items-center w-full py-0.5 px-2 rounded-md transition-colors duration-200 text-sm justify-start',
-      categoryCompleted ? 'bg-green-50' : 'bg-white hover:bg-gray-100'
-    ]"
   >
     <!-- Icon aligned with checkbox column -->
-    <span class="flex-none w-4 h-4 mr-2 flex items-center justify-center" :class="isHovered ? 'text-primary' : 'text-secondary'">
-      <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+    <span
+      class="flex-none w-4 h-4 mr-2 flex items-center justify-center"
+      :class="isHovered ? 'text-primary' : 'text-secondary'"
+    >
+      <svg
+        class="w-4 h-4"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+        />
       </svg>
     </span>
 
     <!-- Label aligns with item name area -->
-    <span class="flex-grow text-base text-left" :class="isHovered ? 'text-primary' : 'text-secondary'">{{ $t('item.newItem') }}</span>
+    <span
+      class="flex-grow text-base text-left"
+      :class="isHovered ? 'text-primary' : 'text-secondary'"
+    >
+      {{ $t('item.newItem') }}
+    </span>
   </button>
 </template>
 

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -104,6 +104,10 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed, nextTick, ref, watch } from 'vue';
 import draggable from 'vuedraggable';
 import { Category } from '../models/Category';

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -23,13 +23,13 @@ Created: 2025-09-19
           v-if="isEditing"
           :id="`category-${category.id}-name`"
           :name="`category-${category.id}-name`"
+          ref="editInput"
           v-model="editedName"
+          class="w-full text-xl font-semibold text-slate-800 bg-transparent border-b border-blue-300 focus:outline-none focus:border-blue-500"
           @keyup.enter="saveEdit"
           @keyup.escape="cancelEdit"
           @blur="saveEdit"
-          ref="editInput"
-          class="w-full text-xl font-semibold text-slate-800 bg-transparent border-b border-blue-300 focus:outline-none focus:border-blue-500"
-        >
+        />
         <h3
           v-else
           class="text-xl font-semibold text-primary cursor-pointer hover:bg-gray-50 px-1 py-1 rounded"
@@ -44,9 +44,9 @@ Created: 2025-09-19
         :item-id="category.id"
         menu-type="category"
         alignment="left"
+        class="ml-2"
         @edit="startEdit"
         @delete="handleDelete"
-        class="ml-2"
       />
     </div>
 
@@ -60,6 +60,7 @@ Created: 2025-09-19
     <!-- Items List -->
     <div class="space-y-0.5">
       <draggable
+        item-key="id"
         v-model="draggableItems"
         :group="{ 
           name: 'items', 
@@ -69,7 +70,6 @@ Created: 2025-09-19
             return from.options.group.name === 'items';
           }
         }"
-        item-key="id"
         :animation="200"
         :ghost-class="'ghost-item'"
         :chosen-class="'chosen-item'"
@@ -95,8 +95,8 @@ Created: 2025-09-19
       </draggable>
 
       <AddItemButton
-        class="px-2 py-1 text-sm"
         :category-completed="isCompleted"
+        class="px-2 py-1 text-sm"
         @click="$emit('create:item', category.id)"
       />
     </div>

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -27,14 +27,14 @@ Created: 2025-09-19
               @keyup.escape="cancelEdit"
               ref="destinationInput"
               class="w-full text-2xl md:text-3xl font-bold text-primary bg-transparent border-b-2 border-blue-300 focus:outline-none focus:border-blue-500 min-w-0"
-              placeholder="Destination"
+              :placeholder="$t('checklist.destination')"
             />
             <h2
               v-else
               class="text-2xl md:text-3xl font-bold text-primary cursor-pointer hover:bg-gray-50 px-1 py-1 rounded truncate"
               @click="startEdit"
             >
-              {{ checklist.destination || 'Untitled Checklist' }}
+              {{ checklist.destination || $t('checklist.untitled') }}
             </h2>
           </div>
 
@@ -149,12 +149,23 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed, nextTick, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import draggable from 'vuedraggable';
 import AddCategoryButton from './AddCategoryButton.vue';
 import Category from './Category.vue';
 import OverflowMenu from './OverflowMenu.vue';
 import ProgressBar from './ProgressBar.vue';
+
+// ----------------------
+// Internationalization (i18n)
+// ----------------------
+
+const { t } = useI18n();
 
 // ----------------------
 // Props & Emits
@@ -295,7 +306,7 @@ function saveEdit() {
   if (hasDestinationChanged || hasStartDateChanged || hasEndDateChanged) {
     const updatedChecklist = {
       ...props.checklist,
-      destination: editedDestination.value.trim() || 'Untitled Checklist',
+      destination: editedDestination.value.trim() || t('checklist.untitled'),
       startDate: editedStartDate.value,
       endDate: editedEndDate.value
     };

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -17,17 +17,21 @@ Created: 2025-09-19
       <div class="flex items-center justify-between mb-4 min-h-[4rem] gap-4">
         <div class="flex items-baseline space-x-4 flex-grow min-w-0">
           <!-- Editable destination name -->
-          <div class="flex-grow min-h-[3rem] flex items-center min-w-0" @blur="handleEditBlur" @focusout="handleEditBlur">
+          <div
+            class="flex-grow min-h-[3rem] flex items-center min-w-0"
+            @blur="handleEditBlur"
+            @focusout="handleEditBlur"
+          >
             <input
               v-if="isEditing"
               :id="`checklist-${checklist.id}-destination`"
               :name="`checklist-${checklist.id}-destination`"
+              ref="destinationInput"
               v-model="editedDestination"
+              :placeholder="$t('checklist.destination')"
+              class="w-full text-2xl md:text-3xl font-bold text-primary bg-transparent border-b-2 border-blue-300 focus:outline-none focus:border-blue-500 min-w-0"
               @keyup.enter="saveEdit"
               @keyup.escape="cancelEdit"
-              ref="destinationInput"
-              class="w-full text-2xl md:text-3xl font-bold text-primary bg-transparent border-b-2 border-blue-300 focus:outline-none focus:border-blue-500 min-w-0"
-              :placeholder="$t('checklist.destination')"
             />
             <h2
               v-else
@@ -39,29 +43,36 @@ Created: 2025-09-19
           </div>
 
           <!-- Editable dates -->
-          <div class="flex items-center space-x-2 min-h-[2.5rem] flex-shrink-0" @blur="handleEditBlur" @focusout="handleEditBlur">
-            <div v-if="isEditing" class="flex items-center space-x-1 sm:space-x-2 flex-wrap sm:flex-nowrap">
+          <div
+            class="flex items-center space-x-2 min-h-[2.5rem] flex-shrink-0"
+            @blur="handleEditBlur"
+            @focusout="handleEditBlur"
+          >
+            <div
+              v-if="isEditing"
+              class="flex items-center space-x-1 sm:space-x-2 flex-wrap sm:flex-nowrap"
+            >
               <input
-                type="date"
                 :id="`checklist-${checklist.id}-start-date`"
                 :name="`checklist-${checklist.id}-start-date`"
+                ref="startDateInput"
                 v-model="editedStartDate"
+                type="date"
+                class="text-sm sm:text-base text-secondary bg-transparent border border-gray-300 rounded px-1 sm:px-2 py-1 focus:outline-none focus:border-blue-500 w-28 sm:w-auto"
                 @keyup.enter="saveEdit"
                 @keyup.escape="cancelEdit"
-                ref="startDateInput"
-                class="text-sm sm:text-base text-secondary bg-transparent border border-gray-300 rounded px-1 sm:px-2 py-1 focus:outline-none focus:border-blue-500 w-28 sm:w-auto"
               />
               <span class="text-secondary hidden sm:inline">-</span>
               <input
-                type="date"
                 :id="`checklist-${checklist.id}-end-date`"
                 :name="`checklist-${checklist.id}-end-date`"
-                v-model="editedEndDate"
-                @keyup.enter="saveEdit"
-                @keyup.escape="cancelEdit"
                 ref="endDateInput"
+                v-model="editedEndDate"
+                type="date"
                 :min="editedStartDate"
                 class="text-sm sm:text-base text-secondary bg-transparent border border-gray-300 rounded px-1 sm:px-2 py-1 focus:outline-none focus:border-blue-500 w-28 sm:w-auto"
+                @keyup.enter="saveEdit"
+                @keyup.escape="cancelEdit"
               />
             </div>
             <span
@@ -78,13 +89,13 @@ Created: 2025-09-19
         <div class="flex-shrink-0">
           <OverflowMenu
             :item-id="checklist.id"
-            menu-type="checklist"
-            alignment="left"
             :force-visible="true"
             :use-group-hover="false"
+            menu-type="checklist"
+            alignment="left"
+            class="ml-2"
             @edit="startEdit"
             @delete="handleDelete"
-            class="ml-2"
           />
         </div>
       </div>
@@ -99,6 +110,7 @@ Created: 2025-09-19
     <!-- Categories Grid -->
     <div>
       <draggable
+        item-key="id"
         v-model="draggableCategories"
         :group="{ 
           name: 'categories', 
@@ -108,7 +120,6 @@ Created: 2025-09-19
             return from.options.group.name === 'categories';
           }
         }"
-        item-key="id"
         :animation="200"
         :ghost-class="'ghost-category'"
         :chosen-class="'chosen-category'"

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -20,10 +20,10 @@ Created: 2025-09-19
     @mouseleave="isHovered = false"
   >
     <input
-      type="checkbox"
+      v-model="isItemPacked"
       :id="`item-${item.id}-packed`"
       :name="`item-${item.id}-packed`"
-      v-model="isItemPacked"
+      type="checkbox"
       :class="[
         'flex-none flex-shrink-0 w-4 h-4 mr-2 rounded-full',
         isItemPacked ? 'border-green-300 accent-green-600' : 'border-gray-300 accent-gray-600'
@@ -32,23 +32,35 @@ Created: 2025-09-19
     />
 
     <!-- Item name - editable when in edit mode -->
-    <div class="flex-grow" @blur="handleEditBlur" @focusout="handleEditBlur">
+    <div
+      class="flex-grow"
+      @blur="handleEditBlur"
+      @focusout="handleEditBlur"
+    >
       <input
         v-if="isEditing"
         :id="`item-${item.id}-name`"
         :name="`item-${item.id}-name`"
+        ref="editInput"
         v-model="editedName"
+        :class="[
+          'w-full text-base bg-transparent border-b border-blue-300 focus:outline-none focus:border-blue-500',
+          {
+            'line-through text-secondary': item.isPacked
+          }
+        ]"
         @keyup.enter="saveEdit"
         @keyup.escape="cancelEdit"
-        ref="editInput"
-        class="w-full text-base bg-transparent border-b border-blue-300 focus:outline-none focus:border-blue-500"
-        :class="{ 'line-through text-secondary': item.isPacked }"
       />
 
       <span
         v-else
-        class="text-base cursor-pointer hover:bg-gray-50 px-1 py-1 rounded"
-        :class="{ 'line-through text-secondary': item.isPacked }"
+        :class="[
+          'text-base cursor-pointer hover:bg-gray-50 px-1 py-1 rounded',
+          {
+            'line-through text-secondary': item.isPacked
+          }
+        ]"
         @click="startEdit"
       >
         {{ item.name }}
@@ -66,14 +78,14 @@ Created: 2025-09-19
         v-if="isEditing"
         :id="`item-${item.id}-quantity`"
         :name="`item-${item.id}-quantity`"
+        ref="quantityInput"
         v-model.number="editedQuantity"
         type="number"
         min="1"
+        class="w-12 px-1 py-0.5 text-xs font-semibold text-secondary bg-gray-100 border border-gray-300 rounded-full text-center focus:outline-none focus:border-gray-500"
         @keyup.enter="saveEdit"
         @keyup.escape="cancelEdit"
         @click.stop
-        ref="quantityInput"
-        class="w-12 px-1 py-0.5 text-xs font-semibold text-secondary bg-gray-100 border border-gray-300 rounded-full text-center focus:outline-none focus:border-gray-500"
       />
 
       <span
@@ -87,13 +99,13 @@ Created: 2025-09-19
     <!-- Overflow menu -->
     <OverflowMenu
       :item-id="item.id"
-      menu-type="item"
-      alignment="left"
       :force-visible="isHovered"
       :use-group-hover="false"
+      menu-type="item"
+      alignment="left"
+      class="ml-2"
       @edit="startEdit"
       @delete="handleDelete"
-      class="ml-2"
     />
   </div>
 </template>

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -99,6 +99,10 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed, nextTick, ref, watch } from 'vue';
 import { Item } from '../models/Item';
 import OverflowMenu from './OverflowMenu.vue';

--- a/source/components/OverflowMenu.vue
+++ b/source/components/OverflowMenu.vue
@@ -38,7 +38,7 @@ Created: 2025-09-19
         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L15.232 5.232z"></path>
         </svg>
-        Edit
+        {{ $t('common.edit') }}
       </button>
       <button
         @click="handleDelete"
@@ -47,13 +47,17 @@ Created: 2025-09-19
         <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
         </svg>
-        Delete
+        {{ $t('common.delete') }}
       </button>
     </div>
   </div>
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 
 // ----------------------

--- a/source/components/OverflowMenu.vue
+++ b/source/components/OverflowMenu.vue
@@ -10,14 +10,19 @@ Created: 2025-09-19
 -->
 
 <template>
-  <div class="relative" ref="root">
+  <div ref="root" class="relative">
     <button
-      type="button"
       ref="buttonRef"
-      @click.stop="toggleMenu"
+      type="button"
       :class="buttonClass"
+      @click.stop="toggleMenu"
     >
-      <svg :class="svgClass" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+      <svg
+        :class="svgClass"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
         <circle cx="6" cy="12" r="1.5" />
         <circle cx="12" cy="12" r="1.5" />
         <circle cx="18" cy="12" r="1.5" />
@@ -32,20 +37,41 @@ Created: 2025-09-19
       :style="dropdownStyle"
     >
       <button
-        @click="handleEdit"
         class="flex items-center w-full px-3 py-2 text-sm text-primary hover:bg-gray-100"
+        @click="handleEdit"
       >
-        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L15.232 5.232z"></path>
+        <svg
+          class="w-4 h-4 mr-2"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L15.232 5.232z"
+          />
         </svg>
         {{ $t('common.edit') }}
       </button>
+      
       <button
-        @click="handleDelete"
         class="flex items-center w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50"
+        @click="handleDelete"
       >
-        <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+        <svg
+          class="w-4 h-4 mr-2"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+          />
         </svg>
         {{ $t('common.delete') }}
       </button>

--- a/source/components/ProgressBar.vue
+++ b/source/components/ProgressBar.vue
@@ -25,8 +25,21 @@ Created: 2025-09-19
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
 import { computed } from 'vue';
 import { THEME_COLORS } from '../utils/constants';
+
+// ----------------------
+// Constants
+// ----------------------
+
+// Theme colors
+const progressColor = THEME_COLORS.PRIMARY;
+const textColor = THEME_COLORS.TEXT_PRIMARY;
+const backgroundColor = THEME_COLORS.SECONDARY;
 
 // ----------------------
 // Props & Emits
@@ -58,14 +71,5 @@ const percentage = computed(() => {
 const text = computed(() => {
   return `${props.completed} / ${props.total}`;
 });
-
-// ----------------------
-// Constants
-// ----------------------
-
-// Theme colors
-const progressColor = THEME_COLORS.PRIMARY;
-const textColor = THEME_COLORS.TEXT_PRIMARY;
-const backgroundColor = THEME_COLORS.SECONDARY;
 
 </script>

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -136,12 +136,20 @@ Created: 2025-09-19
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
+            <!-- Outer circle -->
             <circle cx="12" cy="12" r="10" stroke-width="2" />
-            <path
-              d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
-              stroke-width="2"
-            />
+
+            <!-- Parallels (latitude-like curves): top, middle (straight), bottom -->
+            <path d="M4  6 c4  2 8  2 16 0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M2 12 h20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M4 18 c4 -2 8 -2 16 0" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+
+            <!-- Meridians (longitude-like curves): left, center (straight), right -->
+            <path d="M12 2 C 6 6  6 18 12 22" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M12 2 v20" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M12 2 C18 6 18 18 12 22" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
           </svg>
         </div>
       </button>

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -26,45 +26,45 @@ Created: 2025-09-19
   >
     <!-- Toggle Button -->
     <button
+      class="w-full rounded-lg hover:bg-gray-100 flex items-center mb-2"
       @click="$emit('toggle-sidebar')"
-      class="p-2 rounded-lg hover:bg-gray-100 mb-2"
     >
-      <svg
-        class="w-6 h-6 text-secondary"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 18 24"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="2"
-          d="M4 6h16M4 12h16M4 18h16">
-        </path>
-      </svg>
-    </button>
-
-    <!-- New Checklist Button -->
-    <button
-      @click="$emit('create-checklist')"
-      class="rounded-lg hover:bg-gray-100 mb-4 flex items-center overflow-hidden whitespace-nowrap"
-      :class="[isExpanded || isMobile ? 'pr-4' : '']"
-    >
-      <div class="p-2 flex-shrink-0">
+      <div class="p-3 flex-shrink-0">
         <svg
           class="w-6 h-6 text-secondary"
           fill="none"
           stroke="currentColor"
-          viewBox="0 0 18 24"
-          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
         >
           <path
             stroke-linecap="round"
             stroke-linejoin="round"
             stroke-width="2"
-            d="M12 4v16m8-8H4">
-          </path>
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
+      </div>
+    </button>
+
+    <!-- New Checklist Button -->
+    <button
+      class="w-full rounded-lg hover:bg-gray-100 flex items-center overflow-hidden whitespace-nowrap mb-4"
+      :class="[ isExpanded || isMobile ? 'pr-4' : '' ]"
+      @click="$emit('create-checklist')"
+    >
+      <div class="p-3 flex-shrink-0">
+        <svg
+          class="w-6 h-6 text-secondary"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M12 4v16m8-8H4"
+          />
         </svg>
       </div>
       <span
@@ -97,7 +97,6 @@ Created: 2025-09-19
               :class="(selectedChecklistId === checklist.id && (isExpanded || isMobile)) ? 'bg-gray-100' : 'hover:bg-gray-100'"
             >
               <button
-                @click="$emit('select-checklist', checklist.id)"
                 :class="[
                   'w-full text-left py-2 px-4 transition-colors duration-300 ease-in-out',
                   (isExpanded || isMobile) ? [
@@ -106,12 +105,13 @@ Created: 2025-09-19
                       : 'text-secondary'
                   ] : ''
                 ]"
+                @click="$emit('select-checklist', checklist.id)"
               >
                 <span
                   class="inline-block transition-all duration-300 ease-in-out"
                   :class="{ 'opacity-0 -translate-x-4': !isExpanded && !isMobile, 'opacity-100 translate-x-0 delay-200': isExpanded || isMobile }"
                 >
-                  {{ checklist.destination }}
+                  {{ checklist.destination || $t('checklist.untitled') }}
                 </span>
               </button>
             </div>
@@ -119,52 +119,46 @@ Created: 2025-09-19
         </ul>
       </div>
     </div>
-
-    <!-- Language setting -->
-    <div class="mt-auto pt-4 border-t border-gray-200 relative" ref="settingsRoot">
+    
+    <!-- Language Setting Button -->
+    <div ref="settingsRoot" class="mt-auto pt-4 relative">
       <button
-        @click="toggleLanguageMenu"
-        class="w-full p-2 rounded-lg hover:bg-gray-100 flex items-center justify-center transition-colors duration-200"
         ref="languageButtonRef"
+        class="w-full rounded-lg hover:bg-gray-100 flex items-center overflow-hidden whitespace-nowrap transition-colors duration-200"
+        :class="[ isExpanded || isMobile ? 'pr-4' : '' ]"
         :aria-label="$t('language.switchLanguage')"
+        :title="$t('language.switchLanguage')"
+        @click="toggleLanguageMenu"
       >
-        <!-- Globe Icon (Heroicons outline) -->
-        <svg
-          class="w-6 h-6 text-secondary flex-shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-          />
-        </svg>
-        <span
-          v-if="isExpanded || isMobile"
-          class="ml-3 text-sm text-secondary transition-opacity duration-300 ease-in-out"
-          :class="{ 'opacity-0': !isExpanded && !isMobile, 'opacity-100 delay-150': isExpanded || isMobile }"
-        >
-          {{ currentLanguageLabel }}
-        </span>
+        <div class="p-3 flex-shrink-0">
+          <svg
+            class="w-6 h-6 text-secondary"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="10" stroke-width="2" />
+            <path
+              d="M2 12h20M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"
+              stroke-width="2"
+            />
+          </svg>
+        </div>
       </button>
 
       <!-- Language Dropdown Menu -->
       <div
         v-if="showLanguageMenu"
         ref="languageDropdownRef"
-        :style="languageDropdownStyle"
         class="bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1 min-w-[160px]"
+        :style="languageDropdownStyle"
       >
         <button
           v-for="lang in availableLanguages"
           :key="lang.code"
-          @click="selectLanguage(lang.code)"
           class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100 transition-colors duration-150"
           :class="currentLocale === lang.code ? 'text-primary font-medium bg-gray-50' : 'text-secondary'"
+          @click="selectLanguage(lang.code)"
         >
           <span class="mr-2">{{ lang.icon }}</span>
           <span>{{ lang.label }}</span>
@@ -176,8 +170,8 @@ Created: 2025-09-19
           >
             <path
               fill-rule="evenodd"
-              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
               clip-rule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
             />
           </svg>
         </button>
@@ -262,11 +256,7 @@ const currentLocale = computed({
   }
 });
 
-// Current language label for display
-const currentLanguageLabel = computed(() => {
-  const current = availableLanguages.find(lang => lang.code === currentLocale.value);
-  return current ? current.label : 'Language';
-});
+// Current language label no longer shown on the button; dropdown indicates selection
 
 // ----------------------
 // Language menu functions
@@ -295,7 +285,7 @@ function positionLanguageDropdown() {
   const btnRect = languageButtonRef.value.getBoundingClientRect();
   const ddRect = languageDropdownRef.value.getBoundingClientRect();
   
-  // Position above the button
+  // Position above the button, aligned to the left
   let left = btnRect.left;
   const top = btnRect.top - ddRect.height - 8; // 8px gap
 

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -48,7 +48,7 @@ Created: 2025-09-19
     <!-- New Checklist Button -->
     <button
       @click="$emit('create-checklist')"
-      class="rounded-lg hover:bg-gray-100 mb-12 flex items-center overflow-hidden whitespace-nowrap"
+      class="rounded-lg hover:bg-gray-100 mb-4 flex items-center overflow-hidden whitespace-nowrap"
       :class="[isExpanded || isMobile ? 'pr-4' : '']"
     >
       <div class="p-2 flex-shrink-0">
@@ -71,7 +71,7 @@ Created: 2025-09-19
         class="text-secondary transition-opacity duration-300 ease-in-out ml-4"
         :class="{ 'opacity-0': !isExpanded && !isMobile, 'opacity-100 delay-150': isExpanded || isMobile }"
       >
-        New Checklist
+        {{ $t('sidebar.newChecklist') }}
       </span>
     </button>
 
@@ -83,7 +83,7 @@ Created: 2025-09-19
             class="inline-block text-primary transition-all duration-300 ease-in-out"
             :class="{ 'opacity-0 -translate-x-4': !isExpanded && !isMobile, 'opacity-100 translate-x-0 delay-150': isExpanded || isMobile }"
           >
-            Checklists
+            {{ $t('sidebar.title') }}
           </span>
         </h1>
         <ul class="space-y-1">
@@ -119,10 +119,94 @@ Created: 2025-09-19
         </ul>
       </div>
     </div>
+
+    <!-- Language setting -->
+    <div class="mt-auto pt-4 border-t border-gray-200 relative" ref="settingsRoot">
+      <button
+        @click="toggleLanguageMenu"
+        class="w-full p-2 rounded-lg hover:bg-gray-100 flex items-center justify-center transition-colors duration-200"
+        ref="languageButtonRef"
+        :aria-label="$t('language.switchLanguage')"
+      >
+        <!-- Globe Icon (Heroicons outline) -->
+        <svg
+          class="w-6 h-6 text-secondary flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <span
+          v-if="isExpanded || isMobile"
+          class="ml-3 text-sm text-secondary transition-opacity duration-300 ease-in-out"
+          :class="{ 'opacity-0': !isExpanded && !isMobile, 'opacity-100 delay-150': isExpanded || isMobile }"
+        >
+          {{ currentLanguageLabel }}
+        </span>
+      </button>
+
+      <!-- Language Dropdown Menu -->
+      <div
+        v-if="showLanguageMenu"
+        ref="languageDropdownRef"
+        :style="languageDropdownStyle"
+        class="bg-white border border-gray-200 rounded-md shadow-lg z-50 py-1 min-w-[160px]"
+      >
+        <button
+          v-for="lang in availableLanguages"
+          :key="lang.code"
+          @click="selectLanguage(lang.code)"
+          class="flex items-center w-full px-4 py-2 text-sm hover:bg-gray-100 transition-colors duration-150"
+          :class="currentLocale === lang.code ? 'text-primary font-medium bg-gray-50' : 'text-secondary'"
+        >
+          <span class="mr-2">{{ lang.icon }}</span>
+          <span>{{ lang.label }}</span>
+          <svg
+            v-if="currentLocale === lang.code"
+            class="w-4 h-4 ml-auto text-primary"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
   </aside>
 </template>
 
 <script setup>
+// ----------------------
+// Imports
+// ----------------------
+
+import { computed, ref, onMounted, onUnmounted } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+// ----------------------
+// Internationalization (i18n)
+// ----------------------
+
+const { locale } = useI18n();
+
+// Available languages configuration
+// TODO: Expand this array when adding more language support
+const availableLanguages = [
+  { code: 'en', label: 'English', icon: '🇺🇸' },
+  { code: 'zh-TW', label: '繁體中文', icon: '🇹🇼' }
+];
+
 // ----------------------
 // Props & Emits
 // ----------------------
@@ -153,5 +237,118 @@ defineProps({
 
 // Emits
 defineEmits(['toggle-sidebar', 'create-checklist', 'select-checklist']);
+
+// ----------------------
+// States
+// ----------------------
+
+// Language menu state
+const showLanguageMenu = ref(false);
+const languageDropdownStyle = ref({});
+const languageDropdownRef = ref(null);
+const languageButtonRef = ref(null);
+const settingsRoot = ref(null);
+
+// ----------------------
+// Computed
+// ----------------------
+
+// Current locale (two-way binding)
+const currentLocale = computed({
+  get: () => locale.value,
+  set: (val) => {
+    locale.value = val;
+    localStorage.setItem('user-locale', val);
+  }
+});
+
+// Current language label for display
+const currentLanguageLabel = computed(() => {
+  const current = availableLanguages.find(lang => lang.code === currentLocale.value);
+  return current ? current.label : 'Language';
+});
+
+// ----------------------
+// Language menu functions
+// ----------------------
+
+// Toggle language dropdown menu
+function toggleLanguageMenu() {
+  const willOpen = !showLanguageMenu.value;
+  showLanguageMenu.value = willOpen;
+  
+  if (willOpen) {
+    // Position dropdown off-screen first to measure
+    languageDropdownStyle.value = { position: 'fixed', left: '-9999px', top: '-9999px', zIndex: 9999 };
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        positionLanguageDropdown();
+      });
+    });
+  }
+}
+
+// Position language dropdown relative to button
+function positionLanguageDropdown() {
+  if (!languageButtonRef.value || !languageDropdownRef.value) return;
+  const btnRect = languageButtonRef.value.getBoundingClientRect();
+  const ddRect = languageDropdownRef.value.getBoundingClientRect();
+  
+  // Position above the button
+  let left = btnRect.left;
+  const top = btnRect.top - ddRect.height - 8; // 8px gap
+
+  // Clamp within viewport with padding
+  const minPadding = 8;
+  const maxLeft = window.innerWidth - ddRect.width - minPadding;
+  if (left < minPadding) left = minPadding;
+  if (left > maxLeft) left = maxLeft;
+
+  languageDropdownStyle.value = {
+    position: 'fixed',
+    left: `${left}px`,
+    top: `${top}px`,
+    zIndex: 9999
+  };
+}
+
+// Select language and close menu
+function selectLanguage(langCode) {
+  currentLocale.value = langCode;
+  showLanguageMenu.value = false;
+}
+
+// Close menu when clicking outside
+function closeLanguageMenu(event) {
+  const target = event.target;
+  const clickedInsideRoot = settingsRoot.value && settingsRoot.value.contains(target);
+  const clickedInsideDropdown = languageDropdownRef.value && languageDropdownRef.value.contains(target);
+  
+  if (!clickedInsideRoot && !clickedInsideDropdown) {
+    showLanguageMenu.value = false;
+  }
+}
+
+// Close menu on scroll
+function closeLanguageMenuOnScroll() {
+  showLanguageMenu.value = false;
+}
+
+// ----------------------
+// Lifecycle Hooks
+// ----------------------
+
+// Set up event listeners for language menu
+onMounted(() => {
+  document.addEventListener('click', closeLanguageMenu);
+  window.addEventListener('scroll', closeLanguageMenuOnScroll, true);
+});
+
+// Clean up event listeners
+onUnmounted(() => {
+  document.removeEventListener('click', closeLanguageMenu);
+  window.removeEventListener('scroll', closeLanguageMenuOnScroll, true);
+});
 
 </script>

--- a/source/components/Topbar.vue
+++ b/source/components/Topbar.vue
@@ -11,25 +11,45 @@ Created: 2025-09-19
 
 <template>
   <header class="w-full bg-white border-b border-gray-200 px-3 py-2 flex items-center justify-between md:hidden">
+    <!-- Toggle Navigation Button -->
     <button
-      @click="$emit('toggle')"
-      aria-label="Open navigation"
       class="p-2 rounded-md hover:bg-gray-100"
+      :aria-label="$t('topbar.toggleNav')"
+      @click="$emit('toggle')"
     >
-      <!-- hamburger icon -->
-      <svg class="w-6 h-6 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path>
+      <svg
+        class="w-6 h-6 text-secondary"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M4 6h16M4 12h16M4 18h16"
+        />
       </svg>
     </button>
 
+    <!-- New Checklist Button -->
     <button
-      @click="$emit('new')"
-      aria-label="New checklist"
       class="p-2 rounded-md hover:bg-gray-100"
+      :aria-label="$t('topbar.newChecklist')"
+      @click="$emit('new')"
     >
-      <!-- plus icon -->
-      <svg class="w-6 h-6 text-secondary" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+      <svg
+        class="w-6 h-6 text-secondary"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M12 4v16m8-8H4"
+        />
       </svg>
     </button>
   </header>

--- a/source/data/defaultItems.js
+++ b/source/data/defaultItems.js
@@ -1,141 +1,33 @@
 /*
 ================================================================================
 File: source/data/defaultItems.js
-Description: Default packing items data with categories for new checklists
-             initialization.
+Description: Dynamic default packing items loader with multi-language support
 Author: Sheng-Wei Chang
 License: MIT (SPDX: MIT)
 Created: 2025-09-19
 ================================================================================
 */
 
-export const defaultItems = [
-  // Note: `id` and `isPacked` are intentionally ignored here. The runtime
-  // `Item` instances are created with generated IDs (`generateSecureId`) and
-  // `isPacked` defaults to false. Keeping IDs out of this static file avoids
-  // confusion and ensures the application uses secure/deterministic ID
-  // generation at runtime.
+import { defaultItemsEN } from './defaultItems_en.js';
+import { defaultItemsZhTW } from './defaultItems_zh-TW.js';
 
-  // Summer Wear
-  { name: "T-shirt",                          category: "Summer Wear",      quantity: 1 },
-  { name: "Shirt",                            category: "Summer Wear",      quantity: 1 },
-  { name: "Light Jacket",                     category: "Summer Wear",      quantity: 1 },
-  { name: "Shorts",                           category: "Summer Wear",      quantity: 1 },
-
-  // Winter Wear
-  { name: "Base Layer",                       category: "Winter Wear",      quantity: 1 },
-  { name: "Long Sleeve Shirt",                category: "Winter Wear",      quantity: 1 },
-  { name: "Hoodie",                           category: "Winter Wear",      quantity: 1 },
-  { name: "Jacket",                           category: "Winter Wear",      quantity: 1 },
-  { name: "Down Jacket",                      category: "Winter Wear",      quantity: 1 },
-  { name: "Windbreaker",                      category: "Winter Wear",      quantity: 1 },
-  { name: "Pants",                            category: "Winter Wear",      quantity: 1 },
-
-  // Underwear
-  { name: "Underwear",                        category: "Underwear",        quantity: 1 },
-  { name: "Socks",                            category: "Underwear",        quantity: 1 },
-  { name: "Pajamas",                          category: "Underwear",        quantity: 1 },
-
-  // Accessories
-  { name: "Cap / Hat",                        category: "Accessories",      quantity: 1 },
-  { name: "Beanie",                           category: "Accessories",      quantity: 1 },
-  { name: "Sunglasses",                       category: "Accessories",      quantity: 1 },
-  { name: "Scarf",                            category: "Accessories",      quantity: 1 },
-  { name: "Gloves",                           category: "Accessories",      quantity: 1 },
-  { name: "Belt",                             category: "Accessories",      quantity: 1 },
-  { name: "Shoes",                            category: "Accessories",      quantity: 1 },
-  { name: "Sandals / Flip Flops",             category: "Accessories",      quantity: 1 },
-  { name: "Backpack",                         category: "Accessories",      quantity: 1 },
-  { name: "Sling Bag",                        category: "Accessories",      quantity: 1 },
-  { name: "Packing Cubes",                    category: "Accessories",      quantity: 1 },
-  { name: "Laundry Bag",                      category: "Accessories",      quantity: 1 },
-  { name: "Swimsuit",                         category: "Accessories",      quantity: 1 },
-
-  // Toiletries
-  { name: "Towel",                            category: "Toiletries",       quantity: 1 },
-  { name: "Toothbrush",                       category: "Toiletries",       quantity: 1 },
-  { name: "Toothpaste",                       category: "Toiletries",       quantity: 1 },
-  { name: "Dental Floss",                     category: "Toiletries",       quantity: 1 },
-  { name: "Facial Cleanser",                  category: "Toiletries",       quantity: 1 },
-  { name: "Cotton Swabs",                     category: "Toiletries",       quantity: 1 },
-  { name: "Comb",                             category: "Toiletries",       quantity: 1 },
-  { name: "Tissues / Wet Wipes",              category: "Toiletries",       quantity: 1 },
-  { name: "Razor / Shaver",                   category: "Toiletries",       quantity: 1 },
-  { name: "Shampoo / Conditioner",            category: "Toiletries",       quantity: 1 },
-  { name: "Soap / Body Wash",                 category: "Toiletries",       quantity: 1 },
-  { name: "Menstrual Products",               category: "Toiletries",       quantity: 1 },
+/**
+ * Get default items based on user's locale
+ * @param {string} locale - User's preferred locale ('en', 'zh-TW', etc.)
+ * @returns {Array} Default items array for the specified locale
+ */
+export function getDefaultItems(locale = 'en') {
+  const itemsMap = {
+    'en': defaultItemsEN,
+    'zh-TW': defaultItemsZhTW,
+    'zh': defaultItemsZhTW  // Fallback for simplified Chinese
+    // TODO: Add support for more languages
+    // - Import new defaultItems_{locale}.js files
+    // - Add entries to itemsMap for new locales (e.g., 'zh-CN', 'ja', 'ko')
+  };
   
-  // Skincare
-  { name: "Sunscreen",                        category: "Skincare",         quantity: 1 },
-  { name: "Skincare Products",                category: "Skincare",         quantity: 1 },
-  { name: "Lip Balm",                         category: "Skincare",         quantity: 1 },
-  { name: "Body Lotion",                      category: "Skincare",         quantity: 1 },
-  { name: "Hand Cream",                       category: "Skincare",         quantity: 1 },
+  return itemsMap[locale] || defaultItemsEN;
+}
 
-  // Smart Devices
-  { name: "Phone / Charger",                  category: "Smart Devices",    quantity: 1 },
-  { name: "Tablet / Charger",                 category: "Smart Devices",    quantity: 1 },
-  { name: "Laptop / Charger",                 category: "Smart Devices",    quantity: 1 },
-  { name: "Headphones / Charger",             category: "Smart Devices",    quantity: 1 },
-
-  // Photography
-  { name: "Camera",                           category: "Photography",      quantity: 1 },
-  { name: "Lens",                             category: "Photography",      quantity: 1 },
-  { name: "Camera Battery / Charger",         category: "Photography",      quantity: 1 },
-  { name: "Memory Card",                      category: "Photography",      quantity: 1 },
-  { name: "Tripod",                           category: "Photography",      quantity: 1 },
-
-  // Documents
-  { name: "Passport",                         category: "Documents",        quantity: 1 },
-  { name: "Visa",                             category: "Documents",        quantity: 1 },
-  { name: "(International) Driver's License", category: "Documents",        quantity: 1 },
-  { name: "ID Photo / Passport Copy",         category: "Documents",        quantity: 1 },
-  { name: "Accommodation Confirmation",       category: "Documents",        quantity: 1 },
-  { name: "Travel Insurance Info",            category: "Documents",        quantity: 1 },
-  { name: "Boarding Pass / Itinerary",        category: "Documents",        quantity: 1 },
-  { name: "Emergency Contacts",               category: "Documents",        quantity: 1 },
-
-  // Finance
-  { name: "Cash / Foreign Currency",          category: "Finance",          quantity: 1 },
-  { name: "Credit Card",                      category: "Finance",          quantity: 1 },
-  { name: "Wallet",                           category: "Finance",          quantity: 1 },
-  { name: "Keys",                             category: "Finance",          quantity: 1 },
-
-  // Medicine
-  { name: "First Aid Kit",                    category: "Medicine",         quantity: 1 },
-  { name: "Hand Sanitizer",                   category: "Medicine",         quantity: 1 },
-  { name: "Cold Medicine",                    category: "Medicine",         quantity: 1 },
-  { name: "Pain Relief Medicine",             category: "Medicine",         quantity: 1 },
-  { name: "Stomach Medicine",                 category: "Medicine",         quantity: 1 },
-  { name: "Allergy Medicine",                 category: "Medicine",         quantity: 1 },
-  { name: "Insect Repellent",                 category: "Medicine",         quantity: 1 },
-  { name: "Face Masks",                       category: "Medicine",         quantity: 1 },
-  { name: "Prescription Medication",          category: "Medicine",         quantity: 1 },
-  { name: "Motion Sickness Pills",            category: "Medicine",         quantity: 1 },
-
-  // Food & Drink
-  { name: "Water Bottle",                     category: "Food & Drink",     quantity: 1 },
-  { name: "Tableware",                        category: "Food & Drink",     quantity: 1 },
-  { name: "Lunch Box",                        category: "Food & Drink",     quantity: 1 },
-  { name: "Cup",                              category: "Food & Drink",     quantity: 1 },
-  { name: "Snacks",                           category: "Food & Drink",     quantity: 1 },
-
-  // Travel Items
-  { name: "Phone Lanyard",                    category: "Travel Items",     quantity: 1 },
-  { name: "Neck Pillow",                      category: "Travel Items",     quantity: 1 },
-  { name: "Eye Mask",                         category: "Travel Items",     quantity: 1 },
-  { name: "Pen",                              category: "Travel Items",     quantity: 1 },
-  { name: "Internet (eSIM / WiFi)",           category: "Travel Items",     quantity: 1 },
-  { name: "Power Bank",                       category: "Travel Items",     quantity: 1 },
-  { name: "Travel Plug Adapter",              category: "Travel Items",     quantity: 1 },
-  { name: "Luggage Strap",                    category: "Travel Items",     quantity: 1 },
-  { name: "Luggage Tags",                     category: "Travel Items",     quantity: 1 },
-
-  // Outdoor Items
-  { name: "Swiss Knife",                      category: "Outdoor Items",    quantity: 1 },
-  { name: "Headlamp / Flashlight",            category: "Outdoor Items",    quantity: 1 },
-  { name: "Batteries",                        category: "Outdoor Items",    quantity: 1 },
-  { name: "Binoculars",                       category: "Outdoor Items",    quantity: 1 },
-  { name: "Umbrella",                         category: "Outdoor Items",    quantity: 1 },
-  { name: "Raincoat",                         category: "Outdoor Items",    quantity: 1 }
-];
+// Backward compatibility: export default English items
+export const defaultItems = defaultItemsEN;

--- a/source/data/defaultItems_en.js
+++ b/source/data/defaultItems_en.js
@@ -1,0 +1,140 @@
+/*
+================================================================================
+File: source/data/defaultItems_en.js
+Description: English version of default packing items for new checklists
+Author: Sheng-Wei Chang
+License: MIT (SPDX: MIT)
+Created: 2025-10-18
+================================================================================
+*/
+
+export const defaultItemsEN = [
+  // Note: `id` and `isPacked` are intentionally ignored here. The runtime
+  // `Item` instances are created with generated IDs (`generateSecureId`) and
+  // `isPacked` defaults to false. Keeping IDs out of this static file avoids
+  // confusion and ensures the application uses secure/deterministic ID
+  // generation at runtime.
+
+  // Summer Wear
+  { name: "T-shirt",                          category: "Summer Wear",      quantity: 1 },
+  { name: "Shirt",                            category: "Summer Wear",      quantity: 1 },
+  { name: "Light Jacket",                     category: "Summer Wear",      quantity: 1 },
+  { name: "Shorts",                           category: "Summer Wear",      quantity: 1 },
+
+  // Winter Wear
+  { name: "Base Layer",                       category: "Winter Wear",      quantity: 1 },
+  { name: "Long Sleeve Shirt",                category: "Winter Wear",      quantity: 1 },
+  { name: "Hoodie",                           category: "Winter Wear",      quantity: 1 },
+  { name: "Jacket",                           category: "Winter Wear",      quantity: 1 },
+  { name: "Down Jacket",                      category: "Winter Wear",      quantity: 1 },
+  { name: "Windbreaker",                      category: "Winter Wear",      quantity: 1 },
+  { name: "Pants",                            category: "Winter Wear",      quantity: 1 },
+
+  // Underwear
+  { name: "Underwear",                        category: "Underwear",        quantity: 1 },
+  { name: "Socks",                            category: "Underwear",        quantity: 1 },
+  { name: "Pajamas",                          category: "Underwear",        quantity: 1 },
+
+  // Accessories
+  { name: "Cap / Hat",                        category: "Accessories",      quantity: 1 },
+  { name: "Beanie",                           category: "Accessories",      quantity: 1 },
+  { name: "Sunglasses",                       category: "Accessories",      quantity: 1 },
+  { name: "Scarf",                            category: "Accessories",      quantity: 1 },
+  { name: "Gloves",                           category: "Accessories",      quantity: 1 },
+  { name: "Belt",                             category: "Accessories",      quantity: 1 },
+  { name: "Shoes",                            category: "Accessories",      quantity: 1 },
+  { name: "Sandals / Flip Flops",             category: "Accessories",      quantity: 1 },
+  { name: "Backpack",                         category: "Accessories",      quantity: 1 },
+  { name: "Sling Bag",                        category: "Accessories",      quantity: 1 },
+  { name: "Packing Cubes",                    category: "Accessories",      quantity: 1 },
+  { name: "Laundry Bag",                      category: "Accessories",      quantity: 1 },
+  { name: "Swimsuit",                         category: "Accessories",      quantity: 1 },
+
+  // Toiletries
+  { name: "Towel",                            category: "Toiletries",       quantity: 1 },
+  { name: "Toothbrush",                       category: "Toiletries",       quantity: 1 },
+  { name: "Toothpaste",                       category: "Toiletries",       quantity: 1 },
+  { name: "Dental Floss",                     category: "Toiletries",       quantity: 1 },
+  { name: "Facial Cleanser",                  category: "Toiletries",       quantity: 1 },
+  { name: "Cotton Swabs",                     category: "Toiletries",       quantity: 1 },
+  { name: "Comb",                             category: "Toiletries",       quantity: 1 },
+  { name: "Tissues / Wet Wipes",              category: "Toiletries",       quantity: 1 },
+  { name: "Razor / Shaver",                   category: "Toiletries",       quantity: 1 },
+  { name: "Shampoo / Conditioner",            category: "Toiletries",       quantity: 1 },
+  { name: "Soap / Body Wash",                 category: "Toiletries",       quantity: 1 },
+  { name: "Menstrual Products",               category: "Toiletries",       quantity: 1 },
+  
+  // Skincare
+  { name: "Sunscreen",                        category: "Skincare",         quantity: 1 },
+  { name: "Skincare Products",                category: "Skincare",         quantity: 1 },
+  { name: "Lip Balm",                         category: "Skincare",         quantity: 1 },
+  { name: "Body Lotion",                      category: "Skincare",         quantity: 1 },
+  { name: "Hand Cream",                       category: "Skincare",         quantity: 1 },
+
+  // Smart Devices
+  { name: "Phone / Charger",                  category: "Smart Devices",    quantity: 1 },
+  { name: "Tablet / Charger",                 category: "Smart Devices",    quantity: 1 },
+  { name: "Laptop / Charger",                 category: "Smart Devices",    quantity: 1 },
+  { name: "Headphones / Charger",             category: "Smart Devices",    quantity: 1 },
+
+  // Photography
+  { name: "Camera",                           category: "Photography",      quantity: 1 },
+  { name: "Lens",                             category: "Photography",      quantity: 1 },
+  { name: "Camera Battery / Charger",         category: "Photography",      quantity: 1 },
+  { name: "Memory Card",                      category: "Photography",      quantity: 1 },
+  { name: "Tripod",                           category: "Photography",      quantity: 1 },
+
+  // Documents
+  { name: "Passport",                         category: "Documents",        quantity: 1 },
+  { name: "Visa",                             category: "Documents",        quantity: 1 },
+  { name: "(International) Driver's License", category: "Documents",        quantity: 1 },
+  { name: "ID Photo / Passport Copy",         category: "Documents",        quantity: 1 },
+  { name: "Accommodation Confirmation",       category: "Documents",        quantity: 1 },
+  { name: "Travel Insurance Info",            category: "Documents",        quantity: 1 },
+  { name: "Boarding Pass / Itinerary",        category: "Documents",        quantity: 1 },
+  { name: "Emergency Contacts",               category: "Documents",        quantity: 1 },
+
+  // Finance
+  { name: "Cash / Foreign Currency",          category: "Finance",          quantity: 1 },
+  { name: "Credit Card",                      category: "Finance",          quantity: 1 },
+  { name: "Wallet",                           category: "Finance",          quantity: 1 },
+  { name: "Keys",                             category: "Finance",          quantity: 1 },
+
+  // Medicine
+  { name: "First Aid Kit",                    category: "Medicine",         quantity: 1 },
+  { name: "Hand Sanitizer",                   category: "Medicine",         quantity: 1 },
+  { name: "Cold Medicine",                    category: "Medicine",         quantity: 1 },
+  { name: "Pain Relief Medicine",             category: "Medicine",         quantity: 1 },
+  { name: "Stomach Medicine",                 category: "Medicine",         quantity: 1 },
+  { name: "Allergy Medicine",                 category: "Medicine",         quantity: 1 },
+  { name: "Insect Repellent",                 category: "Medicine",         quantity: 1 },
+  { name: "Face Masks",                       category: "Medicine",         quantity: 1 },
+  { name: "Prescription Medication",          category: "Medicine",         quantity: 1 },
+  { name: "Motion Sickness Pills",            category: "Medicine",         quantity: 1 },
+
+  // Food & Drink
+  { name: "Water Bottle",                     category: "Food & Drink",     quantity: 1 },
+  { name: "Tableware",                        category: "Food & Drink",     quantity: 1 },
+  { name: "Lunch Box",                        category: "Food & Drink",     quantity: 1 },
+  { name: "Cup",                              category: "Food & Drink",     quantity: 1 },
+  { name: "Snacks",                           category: "Food & Drink",     quantity: 1 },
+
+  // Travel Items
+  { name: "Phone Lanyard",                    category: "Travel Items",     quantity: 1 },
+  { name: "Neck Pillow",                      category: "Travel Items",     quantity: 1 },
+  { name: "Eye Mask",                         category: "Travel Items",     quantity: 1 },
+  { name: "Pen",                              category: "Travel Items",     quantity: 1 },
+  { name: "Internet (eSIM / WiFi)",           category: "Travel Items",     quantity: 1 },
+  { name: "Power Bank",                       category: "Travel Items",     quantity: 1 },
+  { name: "Travel Plug Adapter",              category: "Travel Items",     quantity: 1 },
+  { name: "Luggage Strap",                    category: "Travel Items",     quantity: 1 },
+  { name: "Luggage Tags",                     category: "Travel Items",     quantity: 1 },
+
+  // Outdoor Items
+  { name: "Swiss Knife",                      category: "Outdoor Items",    quantity: 1 },
+  { name: "Headlamp / Flashlight",            category: "Outdoor Items",    quantity: 1 },
+  { name: "Batteries",                        category: "Outdoor Items",    quantity: 1 },
+  { name: "Binoculars",                       category: "Outdoor Items",    quantity: 1 },
+  { name: "Umbrella",                         category: "Outdoor Items",    quantity: 1 },
+  { name: "Raincoat",                         category: "Outdoor Items",    quantity: 1 }
+];

--- a/source/data/defaultItems_zh-TW.js
+++ b/source/data/defaultItems_zh-TW.js
@@ -1,0 +1,134 @@
+/*
+================================================================================
+File: source/data/defaultItems_zh-TW.js
+Description: Traditional Chinese version of default packing items for new checklists
+Author: Sheng-Wei Chang
+License: MIT (SPDX: MIT)
+Created: 2025-10-18
+================================================================================
+*/
+
+export const defaultItemsZhTW = [
+  // 夏季服裝
+  { name: "T恤",                    category: "夏季服裝",      quantity: 1 },
+  { name: "襯衫",                    category: "夏季服裝",      quantity: 1 },
+  { name: "輕便外套",                 category: "夏季服裝",      quantity: 1 },
+  { name: "短褲",                    category: "夏季服裝",      quantity: 1 },
+
+  // 冬季服裝
+  { name: "發熱衣",                   category: "冬季服裝",      quantity: 1 },
+  { name: "長袖上衣",                  category: "冬季服裝",      quantity: 1 },
+  { name: "帽T",                     category: "冬季服裝",      quantity: 1 },
+  { name: "外套",                    category: "冬季服裝",      quantity: 1 },
+  { name: "羽絨外套",                  category: "冬季服裝",      quantity: 1 },
+  { name: "防風外套",                  category: "冬季服裝",      quantity: 1 },
+  { name: "長褲",                    category: "冬季服裝",      quantity: 1 },
+
+  // 內衣褲
+  { name: "內衣褲",                   category: "內衣褲",        quantity: 1 },
+  { name: "襪子",                    category: "內衣褲",        quantity: 1 },
+  { name: "睡衣",                    category: "內衣褲",        quantity: 1 },
+
+  // 配件
+  { name: "帽子",                    category: "配件",          quantity: 1 },
+  { name: "毛帽",                    category: "配件",          quantity: 1 },
+  { name: "太陽眼鏡",                  category: "配件",          quantity: 1 },
+  { name: "圍巾",                    category: "配件",          quantity: 1 },
+  { name: "手套",                    category: "配件",          quantity: 1 },
+  { name: "皮帶",                    category: "配件",          quantity: 1 },
+  { name: "鞋子",                    category: "配件",          quantity: 1 },
+  { name: "涼鞋/拖鞋",                 category: "配件",          quantity: 1 },
+  { name: "後背包",                   category: "配件",          quantity: 1 },
+  { name: "斜背包",                   category: "配件",          quantity: 1 },
+  { name: "旅行收納袋",                 category: "配件",          quantity: 1 },
+  { name: "洗衣袋",                   category: "配件",          quantity: 1 },
+  { name: "泳衣",                    category: "配件",          quantity: 1 },
+
+  // 盥洗用品
+  { name: "毛巾",                    category: "盥洗用品",       quantity: 1 },
+  { name: "牙刷",                    category: "盥洗用品",       quantity: 1 },
+  { name: "牙膏",                    category: "盥洗用品",       quantity: 1 },
+  { name: "牙線",                    category: "盥洗用品",       quantity: 1 },
+  { name: "洗面乳",                   category: "盥洗用品",       quantity: 1 },
+  { name: "棉花棒",                   category: "盥洗用品",       quantity: 1 },
+  { name: "梳子",                    category: "盥洗用品",       quantity: 1 },
+  { name: "面紙/濕紙巾",               category: "盥洗用品",       quantity: 1 },
+  { name: "刮鬍刀",                   category: "盥洗用品",       quantity: 1 },
+  { name: "洗髮精/潤髮乳",              category: "盥洗用品",       quantity: 1 },
+  { name: "沐浴乳/香皂",               category: "盥洗用品",       quantity: 1 },
+  { name: "生理用品",                  category: "盥洗用品",       quantity: 1 },
+  
+  // 保養品
+  { name: "防曬乳",                   category: "保養品",         quantity: 1 },
+  { name: "保養品",                   category: "保養品",         quantity: 1 },
+  { name: "護唇膏",                   category: "保養品",         quantity: 1 },
+  { name: "身體乳",                   category: "保養品",         quantity: 1 },
+  { name: "護手霜",                   category: "保養品",         quantity: 1 },
+
+  // 電子產品
+  { name: "手機/充電器",               category: "電子產品",       quantity: 1 },
+  { name: "平板/充電器",               category: "電子產品",       quantity: 1 },
+  { name: "筆電/充電器",               category: "電子產品",       quantity: 1 },
+  { name: "耳機/充電器",               category: "電子產品",       quantity: 1 },
+
+  // 攝影器材
+  { name: "相機",                    category: "攝影器材",       quantity: 1 },
+  { name: "鏡頭",                    category: "攝影器材",       quantity: 1 },
+  { name: "相機電池/充電器",            category: "攝影器材",       quantity: 1 },
+  { name: "記憶卡",                   category: "攝影器材",       quantity: 1 },
+  { name: "腳架",                    category: "攝影器材",       quantity: 1 },
+
+  // 證件文件
+  { name: "護照",                     category: "證件文件",        quantity: 1 },
+  { name: "簽證",                     category: "證件文件",        quantity: 1 },
+  { name: "(國際)駕照",                category: "證件文件",        quantity: 1 },
+  { name: "證件照/護照影本",            category: "證件文件",        quantity: 1 },
+  { name: "住宿確認單",                category: "證件文件",        quantity: 1 },
+  { name: "旅遊保險資訊",               category: "證件文件",        quantity: 1 },
+  { name: "登機證/行程單",              category: "證件文件",        quantity: 1 },
+  { name: "緊急聯絡人資訊",             category: "證件文件",        quantity: 1 },
+
+  // 金融物品
+  { name: "現金/外幣",                category: "金融物品",        quantity: 1 },
+  { name: "信用卡",                   category: "金融物品",        quantity: 1 },
+  { name: "錢包",                    category: "金融物品",        quantity: 1 },
+  { name: "鑰匙",                    category: "金融物品",        quantity: 1 },
+
+  // 藥品
+  { name: "急救包",                   category: "藥品",          quantity: 1 },
+  { name: "乾洗手",                   category: "藥品",          quantity: 1 },
+  { name: "感冒藥",                   category: "藥品",          quantity: 1 },
+  { name: "止痛藥",                   category: "藥品",          quantity: 1 },
+  { name: "腸胃藥",                   category: "藥品",          quantity: 1 },
+  { name: "過敏藥",                   category: "藥品",          quantity: 1 },
+  { name: "防蚊液",                   category: "藥品",          quantity: 1 },
+  { name: "口罩",                    category: "藥品",          quantity: 1 },
+  { name: "處方藥物",                  category: "藥品",          quantity: 1 },
+  { name: "暈車藥",                   category: "藥品",          quantity: 1 },
+
+  // 飲食用品
+  { name: "水壺",                    category: "飲食用品",        quantity: 1 },
+  { name: "餐具",                    category: "飲食用品",        quantity: 1 },
+  { name: "便當盒",                   category: "飲食用品",        quantity: 1 },
+  { name: "杯子",                    category: "飲食用品",        quantity: 1 },
+  { name: "零食",                    category: "飲食用品",        quantity: 1 },
+
+  // 旅行用品
+  { name: "手機掛繩",                  category: "旅行用品",        quantity: 1 },
+  { name: "頸枕",                    category: "旅行用品",        quantity: 1 },
+  { name: "眼罩",                    category: "旅行用品",        quantity: 1 },
+  { name: "筆",                     category: "旅行用品",        quantity: 1 },
+  { name: "網路(eSIM/WiFi)",         category: "旅行用品",        quantity: 1 },
+  { name: "行動電源",                  category: "旅行用品",        quantity: 1 },
+  { name: "萬國插座轉接頭",              category: "旅行用品",        quantity: 1 },
+  { name: "行李束帶",                  category: "旅行用品",        quantity: 1 },
+  { name: "行李吊牌",                  category: "旅行用品",        quantity: 1 },
+
+  // 戶外用品
+  { name: "瑞士刀",                   category: "戶外用品",        quantity: 1 },
+  { name: "頭燈/手電筒",               category: "戶外用品",        quantity: 1 },
+  { name: "電池",                    category: "戶外用品",        quantity: 1 },
+  { name: "望遠鏡",                   category: "戶外用品",        quantity: 1 },
+  { name: "雨傘",                    category: "戶外用品",        quantity: 1 },
+  { name: "雨衣",                    category: "戶外用品",        quantity: 1 }
+];

--- a/source/i18n/index.js
+++ b/source/i18n/index.js
@@ -1,0 +1,130 @@
+/*
+================================================================================
+File: source/i18n/index.js
+Description: i18n configuration for Vue application with locale persistence
+Author: Sheng-Wei Chang
+License: MIT (SPDX: MIT)
+Created: 2025-10-18
+================================================================================
+*/
+
+import { createI18n } from 'vue-i18n';
+import en from '../locales/en.json';
+import zhTW from '../locales/zh-TW.json';
+
+// Local storage key for user language preference
+const LOCALE_STORAGE_KEY = 'user-locale';
+
+// Supported locales
+const SUPPORTED_LOCALES = ['en', 'zh-TW'];
+
+// TODO: Add support for more languages (e.g., zh-CN, ja, ko, es, fr)
+// - Update SUPPORTED_LOCALES array
+// - Add corresponding locale JSON files in ../locales/
+// - Update mapToSupportedLocale() to handle new language mappings
+// - Create defaultItems.{locale}.js files for new languages
+
+/**
+ * Map browser language to supported locale
+ * @param {string} lang - Browser language code
+ * @returns {string} Mapped locale ('en' or 'zh-TW')
+ */
+function mapToSupportedLocale(lang) {
+  if (!lang) return 'en';
+  
+  const lower = String(lang).toLowerCase();
+  
+  // Match all Traditional Chinese variants to zh-TW
+  // Covers: zh, zh-TW, zh-Hant, zh-HK, zh-MO
+  if (
+    lower === 'zh' ||
+    lower.startsWith('zh-') ||
+    lower.includes('hant') ||
+    lower.includes('tw') ||
+    lower.includes('hk') ||
+    lower.includes('mo')
+  ) {
+    return 'zh-TW';
+  }
+  
+  // Default to English for all other cases
+  return 'en';
+}
+
+/**
+ * Detect user's preferred language with priority:
+ * 1) Saved preference in localStorage
+ * 2) Browser language detection
+ * 3) Fallback to English
+ * @returns {string} Locale string ('en' or 'zh-TW')
+ */
+function getPreferredLocale() {
+  // 1. Check saved preference first
+  const savedLocale = localStorage.getItem(LOCALE_STORAGE_KEY);
+  if (savedLocale && SUPPORTED_LOCALES.includes(savedLocale)) {
+    return savedLocale;
+  }
+
+  // 2. Detect browser language (prefer navigator.languages array)
+  const browserLangs = Array.isArray(navigator.languages) && navigator.languages.length
+    ? navigator.languages
+    : [navigator.language || navigator.userLanguage];
+  
+  // Try each browser language candidate
+  for (const lang of browserLangs) {
+    const mapped = mapToSupportedLocale(lang);
+    if (SUPPORTED_LOCALES.includes(mapped)) {
+      return mapped;
+    }
+  }
+
+  // 3. Default to English
+  return 'en';
+}
+
+// Detect initial locale
+const initialLocale = getPreferredLocale();
+
+// Create i18n instance
+const i18n = createI18n({
+  legacy: false, // Use Composition API mode
+  locale: initialLocale,
+  fallbackLocale: 'en',
+  messages: {
+    'en': en,
+    'zh-TW': zhTW
+    // TODO: Add messages for additional locales here
+    // Example: 'zh-CN': zhCN, 'ja': ja, 'ko': ko
+  }
+});
+
+// Persist initial detection to localStorage if not already saved
+if (!localStorage.getItem(LOCALE_STORAGE_KEY)) {
+  localStorage.setItem(LOCALE_STORAGE_KEY, initialLocale);
+}
+
+/**
+ * Update locale and persist to localStorage
+ * @param {string} newLocale - New locale to set
+ */
+export function setLocale(newLocale) {
+  if (!SUPPORTED_LOCALES.includes(newLocale)) {
+    console.warn(`Unsupported locale: ${newLocale}`);
+    return;
+  }
+  
+  if (i18n.global.locale) {
+    i18n.global.locale.value = newLocale;
+    localStorage.setItem(LOCALE_STORAGE_KEY, newLocale);
+  }
+}
+
+/**
+ * Get current locale
+ * @returns {string} Current locale
+ */
+export function getLocale() {
+  return i18n.global.locale?.value || 'en';
+}
+
+export default i18n;

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "edit": "Edit",
+    "delete": "Delete",
+    "cancel": "Cancel",
+    "save": "Save",
+    "confirm": "Confirm"
+  },
+  "sidebar": {
+    "title": "Checklists",
+    "newChecklist": "New Checklist",
+    "toggle": "Toggle sidebar"
+  },
+  "topbar": {
+    "toggleNav": "Open navigation",
+    "newChecklist": "New checklist"
+  },
+  "checklist": {
+    "untitled": "Untitled Checklist",
+    "destination": "Destination",
+    "deleteConfirm": "Are you sure you want to delete this checklist?",
+    "cannotDeleteLast": "Cannot delete the last checklist",
+    "defaultName": "My New Checklist",
+    "pleaseCreate": "Please create a new checklist first."
+  },
+  "category": {
+    "newCategory": "New Category",
+    "defaultName": "New Category"
+  },
+  "item": {
+    "newItem": "New Item",
+    "defaultName": "New Item"
+  },
+  "progress": {
+    "label": "{completed} / {total}",
+    "percentage": "{percent}%"
+  },
+  "language": {
+    "select": "Language",
+    "en": "English",
+    "zhTW": "繁體中文",
+    "switchLanguage": "Switch language"
+  }
+}

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -1,0 +1,44 @@
+{
+  "common": {
+    "edit": "編輯",
+    "delete": "刪除",
+    "cancel": "取消",
+    "save": "儲存",
+    "confirm": "確認"
+  },
+  "sidebar": {
+    "title": "清單列表",
+    "newChecklist": "新增清單",
+    "toggle": "切換側邊欄"
+  },
+  "topbar": {
+    "toggleNav": "開啟導覽選單",
+    "newChecklist": "新增清單"
+  },
+  "checklist": {
+    "untitled": "未命名清單",
+    "destination": "目的地",
+    "deleteConfirm": "確定要刪除這個清單嗎？",
+    "cannotDeleteLast": "無法刪除最後一個清單",
+    "defaultName": "我的新清單",
+    "pleaseCreate": "請先建立一個新清單。"
+  },
+  "category": {
+    "newCategory": "新增分類",
+    "defaultName": "新分類"
+  },
+  "item": {
+    "newItem": "新增物品",
+    "defaultName": "新物品"
+  },
+  "progress": {
+    "label": "{completed} / {total}",
+    "percentage": "{percent}%"
+  },
+  "language": {
+    "select": "語言",
+    "en": "English",
+    "zhTW": "繁體中文",
+    "switchLanguage": "切換語言"
+  }
+}

--- a/source/main.js
+++ b/source/main.js
@@ -11,7 +11,9 @@ Created: 2025-09-19
 
 import { createApp } from 'vue'
 import App from './App.vue'
+import i18n from './i18n'
 import './index.css'
 
 const app = createApp(App)
+app.use(i18n)
 app.mount('#app')

--- a/source/services/localStorageService.js
+++ b/source/services/localStorageService.js
@@ -9,7 +9,7 @@ Created: 2025-09-19
 ================================================================================
 */
 
-import { defaultItems } from '../data/defaultItems';
+import { getDefaultItems } from '../data/defaultItems';
 import { Category } from '../models/Category';
 import { Checklist } from '../models/Checklist';
 import { Item } from '../models/Item';
@@ -99,6 +99,10 @@ export class LocalStorageService extends DataService {
    * @returns {Object} Object containing { categories: Array, items: Array }
    */
   _createDefaultData(checklistId) {
+    // Get user's locale preference for default items
+    const userLocale = localStorage.getItem('user-locale') || 'en';
+    const defaultItems = getDefaultItems(userLocale);
+    
     // Extract unique category names from default items
     const categoryNames = [...new Set(defaultItems.map(item => item.category))];
     


### PR DESCRIPTION
This pull request adds internationalization (i18n) to switch between English and Traditional Chinese, including browser-language detection, localStorage persistence, and a Sidebar language switcher. Default seed items are now locale-aware.

Key changes:

Components / UI:
- Add language switcher in Sidebar.vue (globe icon button + dropdown) to select EN / 繁中.
- Inline SVG globe icon.
- Update accessibility texts (`aria-label` / `title`) to reflect the active locale.

Logic & persistence:
- Initialize vue-i18n in index.js with fallbackLocale: 'en' and browser language detection; normalize zh variants (zh, zh-Hant, zh-TW, zh-HK, zh-MO) to zh-TW.
- Persist user selection in localStorage under user-locale; expose helpers to get/set the current locale.
- Wire i18n in main.js so locale changes propagate app-wide.
- Make default items locale-aware via source/data/defaultItems.js; add defaultItems_en.js and defaultItems_zh-TW.js.

Documentation:
- Update product-spec.md with the i18n section.