### PR TITLE
feat: Add pending items category and item-level "isPending" flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ yarn-error.log*
 .eslintcache
 
 # Personal documentation
-docs/learning-path.md
 docs/**-zh.md
 
 # OS generated files

--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -75,7 +75,8 @@ Checklist, Category, and Item are the three core data entities of the app. Below
   - Edit checklist: Edit `destination`, `startDate`, `endDate` (native date inputs, ISO format).
   - Delete checklist: Cascade delete all categories and items under the checklist.
   - Switch checklist: Load that checklist’s categories and items, sorted by `order`.
-- Flow: Create checklist → add categories/items → edit info → switch checklists.
+- Flow:
+  - Create checklist → add categories/items → edit info → switch checklists.
 - Validation:
   - After create:
     - Categories count equals the number of distinct category names in default data; each `checklistId` equals the new checklist ID; `order` is continuous from 0.
@@ -94,7 +95,8 @@ Checklist, Category, and Item are the three core data entities of the app. Below
   - Delete category: Cascade delete all items under it.
   - Reorder categories: Drag to update `order` (starting at 0); persists and remains after reload.
   - Progress display: Calculate completion percentage based on `isPacked` of items within the category.
-- Flow: Add → rename → delete → drag to reorder.
+- Flow:
+  - Add → rename → delete → drag to reorder.
 - Validation:
   - After add: Category `order` is last; localStorage updates; order persists after reload.
   - After delete: Its items disappear from UI and localStorage.
@@ -111,12 +113,28 @@ Checklist, Category, and Item are the three core data entities of the app. Below
   - Dragging:
     - Same category: After reorder, rewrite `order` sequentially (0-based).
     - Cross category: Update target item’s `categoryId` and `order`, and adjust both source and target categories’ other items to keep `order` continuous.
-- Flow: Add → edit → check/uncheck → delete or drag to reorder/move.
+- Flow:
+  - Add → edit → check/uncheck → delete or drag to reorder/move.
 - Validation:
   - After add: Item `order` is last, `isPacked=false`; localStorage updates and persists after reload.
   - After edit/delete: UI updates and persists; deleted item removed from UI and localStorage.
   - Same-category reorder: Each item `order` is continuous from 0; persists after reload.
   - Cross-category move: Target `categoryId` and `order` are correct; remaining items in both categories have continuous `order`; progress updates correctly on both sides.
+
+#### Pending Items (To Buy / To Do)
+
+- Purpose: Provide a virtual, cross-category view for items the user marked as "pending" — this covers both "to-buy" and general "to-do" semantics.
+- Key features:
+  - Toggle pending: Each item has a boolean `isPending`. Toggling an item to pending will automatically clear `isPacked` to avoid contradictory states.
+  - Virtual category: Pending items are shown in a special virtual category (`PendingItemsCategory.vue`) displayed above regular categories when there are pending items. It uses an orange theme and a compact multi-column grid that mirrors the categories' column layout.
+  - Completion (clear pending): Items in the virtual category can be marked as completed (check action) which clears the `isPending` flag and removes them from the virtual category.
+  - Quantity display: In the virtual category the quantity label is shown inline after the item name only when `quantity > 1`.
+- Flow:
+  - Mark item as pending → item appears in Pending Items virtual category → optionally mark as completed (clears `isPending`) → item removed from virtual category.
+- Validation:
+  - Toggling pending sets `isPending` boolean and persists to storage.
+  - When an item is marked pending, `isPacked` is cleared (set to false) to avoid conflicting states.
+  - The virtual category displays all items where `isPending === true` and hides itself when there are none.
 
 #### Progress Tracking
 
@@ -352,6 +370,7 @@ packing-list/
   quantity: number,     // Quantity
   categoryId: string,   // Category ID
   isPacked: boolean,    // Packed status
+  isPending: boolean,   // Pending (to-buy / to-do) status
   checklistId: string,  // Owning checklist ID
   order: number         // Display order (default: 0)
 }

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -25,7 +25,7 @@ Created: 2025-09-19
           ref="editInput"
           v-model="editedName"
           :name="`category-${category.id}-name`"
-          class="w-full border-b border-blue-300 bg-transparent text-xl font-semibold text-slate-800 focus:border-blue-500 focus:outline-none"
+          class="w-full border-b border-blue-300 bg-transparent px-1 py-1 text-xl font-semibold text-slate-800 focus:border-blue-500 focus:outline-none"
           @keyup.enter="saveEdit"
           @keyup.escape="cancelEdit"
           @blur="saveEdit"

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -488,22 +488,26 @@ watch(
 /* Masonry layout using CSS columns */
 .categories-masonry {
   column-count: 1;
-  column-gap: 0.5rem; /* gap-2 */
+  column-gap: 0.75rem; /* gap-3 for better spacing */
 }
 
-@media (min-width: 600px) {
+/* Breakpoints calculated to ensure minimum 280px per column */
+/* 2 columns: 280*2 + 12 = 572px minimum, using 768px for comfort */
+@media (min-width: 768px) {
   .categories-masonry {
     column-count: 2;
   }
 }
 
-@media (min-width: 840px) {
+/* 3 columns: 280*3 + 24 = 864px minimum, using 1180px for comfort */
+@media (min-width: 1180px) {
   .categories-masonry {
     column-count: 3;
   }
 }
 
-@media (min-width: 1280px) {
+/* 4 columns: 280*4 + 36 = 1156px minimum, using 1536px for comfort */
+@media (min-width: 1536px) {
   .categories-masonry {
     column-count: 4;
   }
@@ -513,7 +517,7 @@ watch(
 .category-item {
   break-inside: avoid;
   page-break-inside: avoid; /* For older browsers */
-  margin-bottom: 0.5rem; /* gap-2 */
+  margin-bottom: 0.75rem; /* gap-3 */
   display: inline-block;
   width: 100%;
   transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -107,12 +107,12 @@ Created: 2025-09-19
       />
     </div>
 
-    <!-- Shopping List (Virtual Category) -->
+    <!-- Pending Items (Virtual Category for to-buy / to-do) -->
     <div
-      v-if="toBuyItems.length > 0"
+      v-if="pendingItemsForDisplay.length > 0"
       class="category-item mb-3"
     >
-      <ShoppingListCategory
+      <PendingItemsCategory
         :items="items"
         @update:item="$emit('update:item', $event)"
       />
@@ -179,8 +179,8 @@ import draggable from 'vuedraggable';
 import AddCategoryButton from './AddCategoryButton.vue';
 import Category from './Category.vue';
 import OverflowMenu from './OverflowMenu.vue';
+import PendingItemsCategory from './PendingItemsCategory.vue';
 import ProgressBar from './ProgressBar.vue';
-import ShoppingListCategory from './ShoppingListCategory.vue';
 
 // ------------------------------------------------------------------------------
 // Internationalization (i18n)
@@ -265,9 +265,9 @@ const isDraggingCategory = ref(false);
 // Computed
 // ------------------------------------------------------------------------------
 
-// Filter items that are marked as "to buy" for the shopping list
-const toBuyItems = computed(() => {
-  return props.items.filter((item) => item.isToBuy);
+// Filter items that are marked as pending (to-buy / to-do)
+const pendingItemsForDisplay = computed(() => {
+  return props.items.filter((item) => item.isPending);
 });
 
 // Sorted categories for this checklist (sorted by order)

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -12,9 +12,9 @@ Created: 2025-09-19
 <template>
   <div>
     <!-- Checklist Header -->
-    <div class="mb-2 p-4">
+    <div class="mb-2 px-4 pb-4 pt-2">
       <!-- Header content -->
-      <div class="mb-4 flex min-h-[4rem] items-center justify-between gap-4">
+      <div class="mb-3 flex min-h-[3rem] items-center justify-between gap-4">
         <div class="flex min-w-0 flex-grow items-baseline space-x-4">
           <!-- Editable destination name -->
           <div
@@ -107,6 +107,17 @@ Created: 2025-09-19
       />
     </div>
 
+    <!-- Shopping List (Virtual Category) -->
+    <div
+      v-if="toBuyItems.length > 0"
+      class="category-item mb-3"
+    >
+      <ShoppingListCategory
+        :items="items"
+        @update:item="$emit('update:item', $event)"
+      />
+    </div>
+
     <!-- Categories Grid -->
     <div>
       <draggable
@@ -169,6 +180,7 @@ import AddCategoryButton from './AddCategoryButton.vue';
 import Category from './Category.vue';
 import OverflowMenu from './OverflowMenu.vue';
 import ProgressBar from './ProgressBar.vue';
+import ShoppingListCategory from './ShoppingListCategory.vue';
 
 // ------------------------------------------------------------------------------
 // Internationalization (i18n)
@@ -252,6 +264,11 @@ const isDraggingCategory = ref(false);
 // ------------------------------------------------------------------------------
 // Computed
 // ------------------------------------------------------------------------------
+
+// Filter items that are marked as "to buy" for the shopping list
+const toBuyItems = computed(() => {
+  return props.items.filter((item) => item.isToBuy);
+});
 
 // Sorted categories for this checklist (sorted by order)
 const sortedCategories = computed(() => {

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -29,7 +29,7 @@ Created: 2025-09-19
               v-model="editedDestination"
               :name="`checklist-${checklist.id}-destination`"
               :placeholder="$t('checklist.destination')"
-              class="text-primary w-full min-w-0 border-b-2 border-blue-300 bg-transparent text-2xl font-bold focus:border-blue-500 focus:outline-none md:text-3xl"
+              class="text-primary w-full min-w-0 border-b-2 border-blue-300 bg-transparent px-1 py-1 text-2xl font-bold focus:border-blue-500 focus:outline-none md:text-3xl"
               @keyup.enter="saveEdit"
               @keyup.escape="cancelEdit"
             />

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -68,23 +68,24 @@ Created: 2025-09-19
       </span>
     </div>
 
-    <!-- To Buy icon button - always visible; toggling will clear packed state to keep states mutually exclusive -->
+    <!-- Pending (to-buy / to-do) icon button - always visible; toggling will clear packed state to keep states mutually exclusive -->
     <button
       type="button"
       :class="[
         'ml-1.5 flex h-6 w-6 flex-none items-center justify-center rounded-full transition-colors duration-200 sm:ml-2',
-        item.isToBuy
+        item.isPending
           ? 'bg-orange-500 text-white hover:bg-orange-600'
           : 'bg-gray-200 text-gray-400 hover:bg-gray-300',
-        item.isToBuy || isHovered || isEditing ? 'visible' : 'invisible',
+        item.isPending || isHovered || isEditing ? 'visible' : 'invisible',
       ]"
-      :title="item.isToBuy ? $t('item.markedAsToBuy') : $t('item.markAsToBuy')"
-      :aria-label="item.isToBuy ? $t('item.markedAsToBuy') : $t('item.markAsToBuy')"
-      @click.stop="toggleToBuy"
+      :title="item.isPending ? $t('item.markedAsPending') : $t('item.markAsPending')"
+      :aria-label="item.isPending ? $t('item.markedAsPending') : $t('item.markAsPending')"
+      @click.stop="togglePending"
       @mousedown.prevent
     >
+      <!-- clipboard with checklist icon -->
       <svg
-        class="h-3.5 w-3.5"
+        class="h-4 w-4"
         fill="none"
         stroke="currentColor"
         stroke-width="2"
@@ -92,7 +93,7 @@ Created: 2025-09-19
         xmlns="http://www.w3.org/2000/svg"
       >
         <path
-          d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+          d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
           stroke-linecap="round"
           stroke-linejoin="round"
         />
@@ -232,7 +233,7 @@ const props = defineProps({
         typeof value.quantity === 'number' &&
         typeof value.categoryId === 'string' &&
         typeof value.isPacked === 'boolean' &&
-        typeof value.isToBuy === 'boolean' &&
+        typeof value.isPending === 'boolean' &&
         typeof value.checklistId === 'string'
       );
     },
@@ -279,7 +280,7 @@ const isItemPacked = computed({
       quantity: props.item.quantity,
       categoryId: props.item.categoryId,
       isPacked: newValue,
-      isToBuy: newValue ? false : props.item.isToBuy, // Auto-clear isToBuy when packed
+      isPending: newValue ? false : props.item.isPending, // Auto-clear isPending when packed
       checklistId: props.item.checklistId,
       order: props.item.order,
     });
@@ -292,15 +293,15 @@ const isItemPacked = computed({
 // ------------------------------------------------------------------------------
 
 /**
- * Toggle the to-buy state of the item
+ * Toggle the pending state of the item (to-buy / to-do)
  */
-function toggleToBuy() {
-  const newToBuy = !props.item.isToBuy;
+function togglePending() {
+  const newPending = !props.item.isPending;
   const updatedItem = new Item({
     ...props.item,
-    isToBuy: newToBuy,
-    // If user marks as to-buy, automatically clear packed state to avoid contradiction
-    isPacked: newToBuy ? false : props.item.isPacked,
+    isPending: newPending,
+    // If user marks as pending, automatically clear packed state to avoid contradiction
+    isPacked: newPending ? false : props.item.isPacked,
   });
   emit('update:item', updatedItem);
 }

--- a/source/components/OverflowMenu.vue
+++ b/source/components/OverflowMenu.vue
@@ -14,14 +14,33 @@ Created: 2025-09-19
     ref="root"
     class="relative"
   >
-    <!-- Three-dot menu button -->
+    <!-- Three-dot menu button or checkmark button when editing -->
     <button
       ref="buttonRef"
       type="button"
       :class="buttonClass"
-      @click.stop="toggleMenu"
+      @click.stop="props.isEditing ? handleConfirmEdit() : toggleMenu()"
     >
+      <!-- Checkmark icon when editing -->
       <svg
+        v-if="props.isEditing"
+        :class="svgClass"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          d="M5 13l4 4L19 7"
+        />
+      </svg>
+
+      <!-- Three-dot menu icon when not editing -->
+      <svg
+        v-else
         :class="svgClass"
         fill="currentColor"
         viewBox="0 0 24 24"
@@ -130,10 +149,14 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  isEditing: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 // Emits
-const emit = defineEmits(['edit', 'delete']);
+const emit = defineEmits(['edit', 'delete', 'confirm-edit']);
 
 // ------------------------------------------------------------------------------
 // States
@@ -153,20 +176,28 @@ const root = ref(null);
 // Button visibility based on props and menu state
 const buttonClass = computed(() => {
   const baseClass =
-    'p-1 flex items-center justify-center text-secondary rounded-md transition-opacity duration-200 hover:bg-gray-200 hover:text-primary';
+    'p-1 flex items-center justify-center rounded-md transition-all duration-200 hover:bg-gray-200';
+
+  // Green checkmark style when editing
+  if (props.isEditing) {
+    return `${baseClass} opacity-100 text-green-600 hover:text-green-700 hover:bg-green-50`;
+  }
+
+  // Gray three-dot style when not editing
+  const normalClass = `${baseClass} text-secondary hover:text-primary`;
 
   // Show the button when menu is open or forceVisible is true
   if (showMenu.value || props.forceVisible) {
-    return `${baseClass} opacity-100`;
+    return `${normalClass} opacity-100`;
   }
 
   // If using group-hover behavior (default), show on ancestor hover
   if (props.useGroupHover) {
-    return `${baseClass} opacity-0 group-hover:opacity-100`;
+    return `${normalClass} opacity-0 group-hover:opacity-100`;
   }
 
   // Otherwise keep hidden unless forced or open
-  return `${baseClass} opacity-0`;
+  return `${normalClass} opacity-0`;
 });
 
 // Dropdown styling
@@ -257,6 +288,13 @@ function handleEdit() {
 function handleDelete() {
   showMenu.value = false;
   emit('delete');
+}
+
+/**
+ * Emit confirm-edit event when checkmark is clicked
+ */
+function handleConfirmEdit() {
+  emit('confirm-edit');
 }
 
 // ------------------------------------------------------------------------------

--- a/source/components/PendingItemsCategory.vue
+++ b/source/components/PendingItemsCategory.vue
@@ -1,8 +1,9 @@
 <!--
 ================================================================================
-File: source/components/ShoppingListCategory.vue
-Description: Special virtual category component for displaying items marked as "to buy"
-             Provides a simplified view with shopping cart functionality only
+File: source/components/PendingItemsCategory.vue
+Description: Special virtual category component for displaying pending items
+             (to-buy / to-do). Provides a simplified view with completion
+             functionality.
 Author: Sheng-Wei Chang
 License: MIT (SPDX: MIT)
 Created: 2025-11-01
@@ -11,16 +12,16 @@ Created: 2025-11-01
 
 <template>
   <div
-    v-if="toBuyItems.length > 0"
+    v-if="pendingItems.length > 0"
     class="group rounded-xl p-3 shadow-md transition-all duration-200 hover:shadow-lg"
-    :style="{ backgroundColor: THEME_COLORS.SHOPPING_CART.BACKGROUND }"
+    :style="{ backgroundColor: THEME_COLORS.PENDING_ITEMS.BACKGROUND }"
   >
     <!-- Header -->
     <div class="relative mb-3 flex items-center justify-between">
       <div class="flex-grow">
         <h3
           class="text-primary cursor-pointer rounded px-1 py-1 text-xl font-semibold"
-          :style="{ color: THEME_COLORS.SHOPPING_CART.TEXT }"
+          :style="{ color: THEME_COLORS.PENDING_ITEMS.TEXT }"
         >
           {{ $t('category.shoppingList') }}
         </h3>
@@ -29,33 +30,33 @@ Created: 2025-11-01
       <!-- Item count (replaces overflow menu) -->
       <span
         class="font-medium"
-        :style="{ color: THEME_COLORS.SHOPPING_CART.ACCENT }"
+        :style="{ color: THEME_COLORS.PENDING_ITEMS.ACCENT }"
       >
-        {{ toBuyItems.length }} {{ $t('category.itemsLeft') }}
+        {{ pendingItems.length }} {{ $t('category.itemsLeft') }}
       </span>
     </div>
 
     <!-- Items grid - multi-column layout matching category columns -->
-    <div class="shopping-items-grid">
+    <div class="pending-items-grid">
       <div
-        v-for="item in toBuyItems"
+        v-for="item in pendingItems"
         :key="item.id"
         class="group flex items-center rounded-md py-0.5 pl-1 pr-1 transition-all duration-200"
       >
-        <!-- Shopping cart button (left side) - mark as bought -->
+        <!-- Completion button (left side) - mark as completed -->
         <button
           type="button"
           class="mr-1.5 flex h-5 w-5 flex-none flex-shrink-0 items-center justify-center rounded-full text-white transition-all hover:scale-110 sm:mr-2"
           :style="{
-            backgroundColor: THEME_COLORS.SHOPPING_CART.BUTTON,
+            backgroundColor: THEME_COLORS.PENDING_ITEMS.BUTTON,
           }"
           :title="$t('item.markAsBought')"
           :aria-label="$t('item.markAsBought')"
-          @click.stop="markAsBought(item)"
+          @click.stop="markAsCompleted(item)"
           @mouseenter="
-            (e) => (e.target.style.backgroundColor = THEME_COLORS.SHOPPING_CART.BUTTON_HOVER)
+            (e) => (e.target.style.backgroundColor = THEME_COLORS.PENDING_ITEMS.BUTTON_HOVER)
           "
-          @mouseleave="(e) => (e.target.style.backgroundColor = THEME_COLORS.SHOPPING_CART.BUTTON)"
+          @mouseleave="(e) => (e.target.style.backgroundColor = THEME_COLORS.PENDING_ITEMS.BUTTON)"
         >
           <!-- Checkmark icon -->
           <svg
@@ -73,13 +74,24 @@ Created: 2025-11-01
           </svg>
         </button>
 
-        <!-- Item name -->
-        <span
-          class="flex-grow truncate text-base"
-          :style="{ color: THEME_COLORS.TEXT_PRIMARY }"
-        >
-          {{ item.name }}
-        </span>
+        <!-- Item name and optional quantity -->
+        <div class="flex flex-grow items-center gap-1">
+          <span
+            class="truncate text-base"
+            :style="{ color: THEME_COLORS.TEXT_PRIMARY }"
+          >
+            {{ item.name }}
+          </span>
+
+          <!-- Quantity display (only show if quantity > 1) -->
+          <div
+            v-if="item.quantity > 1"
+            class="text-secondary flex h-6 w-8 flex-shrink-0 items-center justify-center rounded-md bg-gray-100 px-1 text-xs font-semibold"
+          >
+            <span class="mr-0.5">x</span>
+            <span>{{ item.quantity }}</span>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -109,7 +121,7 @@ const props = defineProps({
           item &&
           typeof item.id === 'string' &&
           typeof item.name === 'string' &&
-          typeof item.isToBuy === 'boolean'
+          typeof item.isPending === 'boolean'
       );
     },
   },
@@ -122,10 +134,10 @@ const emit = defineEmits(['update:item']);
 // ------------------------------------------------------------------------------
 
 /**
- * Filter items that are marked as "to buy"
+ * Filter items that are marked as pending (to-buy / to-do)
  */
-const toBuyItems = computed(() => {
-  return props.items.filter((item) => item.isToBuy);
+const pendingItems = computed(() => {
+  return props.items.filter((item) => item.isPending);
 });
 
 // ------------------------------------------------------------------------------
@@ -133,15 +145,15 @@ const toBuyItems = computed(() => {
 // ------------------------------------------------------------------------------
 
 /**
- * Mark an item as bought by removing the isToBuy flag
- * This will automatically remove it from the shopping list
- * @param {object} item - The item to mark as bought
+ * Mark an item as completed by removing the isPending flag
+ * This will automatically remove it from the pending items list
+ * @param {object} item - The item to mark as completed
  */
-function markAsBought(item) {
+function markAsCompleted(item) {
   const updatedItem = new Item({
     ...item,
-    isToBuy: false, // Remove from shopping list
-    // isPacked remains unchanged - buying doesn't mean packing
+    isPending: false, // Remove from pending items list
+    // isPacked remains unchanged - completing doesn't mean packing
   });
   emit('update:item', updatedItem);
 }
@@ -149,7 +161,7 @@ function markAsBought(item) {
 
 <style scoped>
 /* Multi-column grid layout matching category columns */
-.shopping-items-grid {
+.pending-items-grid {
   display: grid;
   column-gap: 2.25rem;
   row-gap: 0.25rem;
@@ -159,21 +171,21 @@ function markAsBought(item) {
 /* Match category column breakpoints (values from index.css :root) */
 /* Source: index.css --breakpoint-tablet */
 @media (min-width: 768px) {
-  .shopping-items-grid {
+  .pending-items-grid {
     grid-template-columns: repeat(2, 1fr);
   }
 }
 
 /* Source: index.css --breakpoint-desktop */
 @media (min-width: 1180px) {
-  .shopping-items-grid {
+  .pending-items-grid {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
 /* Source: index.css --breakpoint-large-desktop */
 @media (min-width: 1536px) {
-  .shopping-items-grid {
+  .pending-items-grid {
     grid-template-columns: repeat(4, 1fr);
   }
 }

--- a/source/components/ShoppingListCategory.vue
+++ b/source/components/ShoppingListCategory.vue
@@ -1,0 +1,180 @@
+<!--
+================================================================================
+File: source/components/ShoppingListCategory.vue
+Description: Special virtual category component for displaying items marked as "to buy"
+             Provides a simplified view with shopping cart functionality only
+Author: Sheng-Wei Chang
+License: MIT (SPDX: MIT)
+Created: 2025-11-01
+================================================================================
+-->
+
+<template>
+  <div
+    v-if="toBuyItems.length > 0"
+    class="group rounded-xl p-3 shadow-md transition-all duration-200 hover:shadow-lg"
+    :style="{ backgroundColor: THEME_COLORS.SHOPPING_CART.BACKGROUND }"
+  >
+    <!-- Header -->
+    <div class="relative mb-3 flex items-center justify-between">
+      <div class="flex-grow">
+        <h3
+          class="text-primary cursor-pointer rounded px-1 py-1 text-xl font-semibold"
+          :style="{ color: THEME_COLORS.SHOPPING_CART.TEXT }"
+        >
+          {{ $t('category.shoppingList') }}
+        </h3>
+      </div>
+
+      <!-- Item count (replaces overflow menu) -->
+      <span
+        class="font-medium"
+        :style="{ color: THEME_COLORS.SHOPPING_CART.ACCENT }"
+      >
+        {{ toBuyItems.length }} {{ $t('category.itemsLeft') }}
+      </span>
+    </div>
+
+    <!-- Items grid - multi-column layout matching category columns -->
+    <div class="shopping-items-grid">
+      <div
+        v-for="item in toBuyItems"
+        :key="item.id"
+        class="group flex items-center rounded-md py-0.5 pl-1 pr-1 transition-all duration-200"
+      >
+        <!-- Shopping cart button (left side) - mark as bought -->
+        <button
+          type="button"
+          class="mr-1.5 flex h-5 w-5 flex-none flex-shrink-0 items-center justify-center rounded-full text-white transition-all hover:scale-110 sm:mr-2"
+          :style="{
+            backgroundColor: THEME_COLORS.SHOPPING_CART.BUTTON,
+          }"
+          :title="$t('item.markAsBought')"
+          :aria-label="$t('item.markAsBought')"
+          @click.stop="markAsBought(item)"
+          @mouseenter="
+            (e) => (e.target.style.backgroundColor = THEME_COLORS.SHOPPING_CART.BUTTON_HOVER)
+          "
+          @mouseleave="(e) => (e.target.style.backgroundColor = THEME_COLORS.SHOPPING_CART.BUTTON)"
+        >
+          <!-- Checkmark icon -->
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M5 13l4 4L19 7"
+            />
+          </svg>
+        </button>
+
+        <!-- Item name -->
+        <span
+          class="flex-grow truncate text-base"
+          :style="{ color: THEME_COLORS.TEXT_PRIMARY }"
+        >
+          {{ item.name }}
+        </span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+// ------------------------------------------------------------------------------
+// Imports
+// ------------------------------------------------------------------------------
+
+import { computed } from 'vue';
+
+import { Item } from '../models/Item';
+import { THEME_COLORS } from '../utils/constants';
+
+// ------------------------------------------------------------------------------
+// Props & Emits
+// ------------------------------------------------------------------------------
+
+const props = defineProps({
+  items: {
+    type: Array,
+    required: true,
+    validator: (items) => {
+      return items.every(
+        (item) =>
+          item &&
+          typeof item.id === 'string' &&
+          typeof item.name === 'string' &&
+          typeof item.isToBuy === 'boolean'
+      );
+    },
+  },
+});
+
+const emit = defineEmits(['update:item']);
+
+// ------------------------------------------------------------------------------
+// Computed
+// ------------------------------------------------------------------------------
+
+/**
+ * Filter items that are marked as "to buy"
+ */
+const toBuyItems = computed(() => {
+  return props.items.filter((item) => item.isToBuy);
+});
+
+// ------------------------------------------------------------------------------
+// Functions
+// ------------------------------------------------------------------------------
+
+/**
+ * Mark an item as bought by removing the isToBuy flag
+ * This will automatically remove it from the shopping list
+ * @param {object} item - The item to mark as bought
+ */
+function markAsBought(item) {
+  const updatedItem = new Item({
+    ...item,
+    isToBuy: false, // Remove from shopping list
+    // isPacked remains unchanged - buying doesn't mean packing
+  });
+  emit('update:item', updatedItem);
+}
+</script>
+
+<style scoped>
+/* Multi-column grid layout matching category columns */
+.shopping-items-grid {
+  display: grid;
+  column-gap: 2.25rem;
+  row-gap: 0.25rem;
+  grid-template-columns: 1fr;
+}
+
+/* Match category column breakpoints (values from index.css :root) */
+/* Source: index.css --breakpoint-tablet */
+@media (min-width: 768px) {
+  .shopping-items-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* Source: index.css --breakpoint-desktop */
+@media (min-width: 1180px) {
+  .shopping-items-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Source: index.css --breakpoint-large-desktop */
+@media (min-width: 1536px) {
+  .shopping-items-grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+</style>

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -25,13 +25,16 @@
   },
   "category": {
     "newCategory": "New Category",
-    "defaultName": "New Category"
+    "defaultName": "New Category",
+    "shoppingList": "Shopping List",
+    "itemsLeft": "items to buy"
   },
   "item": {
     "newItem": "New Item",
     "defaultName": "New Item",
     "markAsToBuy": "Mark as to buy",
     "markedAsToBuy": "Marked as to buy",
+    "markAsBought": "Mark as bought",
     "increaseQuantity": "Increase quantity",
     "decreaseQuantity": "Decrease quantity"
   },

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -29,7 +29,11 @@
   },
   "item": {
     "newItem": "New Item",
-    "defaultName": "New Item"
+    "defaultName": "New Item",
+    "markAsToBuy": "Mark as to buy",
+    "markedAsToBuy": "Marked as to buy",
+    "increaseQuantity": "Increase quantity",
+    "decreaseQuantity": "Decrease quantity"
   },
   "progress": {
     "label": "{completed} / {total}",

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -26,15 +26,15 @@
   "category": {
     "newCategory": "New Category",
     "defaultName": "New Category",
-    "shoppingList": "Shopping List",
-    "itemsLeft": "items to buy"
+    "shoppingList": "To Buy / To Do",
+    "itemsLeft": "items left"
   },
   "item": {
     "newItem": "New Item",
     "defaultName": "New Item",
-    "markAsToBuy": "Mark as to buy",
-    "markedAsToBuy": "Marked as to buy",
-    "markAsBought": "Mark as bought",
+    "markAsPending": "Mark as to buy / to do",
+    "markedAsPending": "Marked as to buy / to do",
+    "markAsBought": "Mark as bought / done",
     "increaseQuantity": "Increase quantity",
     "decreaseQuantity": "Decrease quantity"
   },

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -26,15 +26,15 @@
   "category": {
     "newCategory": "新增分類",
     "defaultName": "新分類",
-    "shoppingList": "購物清單",
-    "itemsLeft": "項待買"
+    "shoppingList": "待買/待辦",
+    "itemsLeft": "項待處理"
   },
   "item": {
     "newItem": "新增物品",
     "defaultName": "新物品",
-    "markAsToBuy": "標記為待買",
-    "markedAsToBuy": "已標記為待買",
-    "markAsBought": "標記已購買",
+    "markAsPending": "標記為待買/待辦",
+    "markedAsPending": "已標記為待買/待辦",
+    "markAsBought": "標記為已買/已辦",
     "increaseQuantity": "增加數量",
     "decreaseQuantity": "減少數量"
   },

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -25,13 +25,16 @@
   },
   "category": {
     "newCategory": "新增分類",
-    "defaultName": "新分類"
+    "defaultName": "新分類",
+    "shoppingList": "購物清單",
+    "itemsLeft": "項待買"
   },
   "item": {
     "newItem": "新增物品",
     "defaultName": "新物品",
     "markAsToBuy": "標記為待買",
     "markedAsToBuy": "已標記為待買",
+    "markAsBought": "標記已購買",
     "increaseQuantity": "增加數量",
     "decreaseQuantity": "減少數量"
   },

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -29,7 +29,11 @@
   },
   "item": {
     "newItem": "新增物品",
-    "defaultName": "新物品"
+    "defaultName": "新物品",
+    "markAsToBuy": "標記為待買",
+    "markedAsToBuy": "已標記為待買",
+    "increaseQuantity": "增加數量",
+    "decreaseQuantity": "減少數量"
   },
   "progress": {
     "label": "{completed} / {total}",

--- a/source/models/Item.js
+++ b/source/models/Item.js
@@ -32,6 +32,7 @@ export class Item {
    * @param {number} root0.quantity - Quantity of the item (1-999)
    * @param {string} root0.categoryId - ID of the category this item belongs to
    * @param {boolean} root0.isPacked - Whether the item is packed
+   * @param {boolean} root0.isToBuy - Whether the item is marked as to buy
    * @param {string} root0.checklistId - ID of the checklist this item belongs to
    * @param {number} root0.order - Display order within category
    */
@@ -41,6 +42,7 @@ export class Item {
     quantity = 1,
     categoryId = null,
     isPacked = false,
+    isToBuy = false,
     checklistId = null,
     order = 0,
   } = {}) {
@@ -49,6 +51,7 @@ export class Item {
     this.quantity = this.validateQuantity(quantity);
     this.categoryId = categoryId;
     this.isPacked = Boolean(isPacked);
+    this.isToBuy = Boolean(isToBuy);
     this.checklistId = checklistId;
     this.order = Number(order) || 0;
   }
@@ -92,10 +95,11 @@ export class Item {
    * @returns {Item} A new Item instance
    */
   static fromJSON(json) {
-    // Ensure isPacked is properly converted to boolean
+    // Ensure isPacked and isToBuy are properly converted to boolean
     const itemData = {
       ...json,
       isPacked: Boolean(json.isPacked),
+      isToBuy: Boolean(json.isToBuy),
     };
     return new Item(itemData);
   }
@@ -111,6 +115,7 @@ export class Item {
       quantity: this.quantity,
       categoryId: this.categoryId,
       isPacked: this.isPacked,
+      isToBuy: this.isToBuy,
       checklistId: this.checklistId,
       order: this.order,
     };

--- a/source/models/Item.js
+++ b/source/models/Item.js
@@ -32,7 +32,7 @@ export class Item {
    * @param {number} root0.quantity - Quantity of the item (1-999)
    * @param {string} root0.categoryId - ID of the category this item belongs to
    * @param {boolean} root0.isPacked - Whether the item is packed
-   * @param {boolean} root0.isToBuy - Whether the item is marked as to buy
+   * @param {boolean} root0.isPending - Whether the item is marked as pending (to-buy / to-do)
    * @param {string} root0.checklistId - ID of the checklist this item belongs to
    * @param {number} root0.order - Display order within category
    */
@@ -42,7 +42,7 @@ export class Item {
     quantity = 1,
     categoryId = null,
     isPacked = false,
-    isToBuy = false,
+    isPending = false,
     checklistId = null,
     order = 0,
   } = {}) {
@@ -51,7 +51,7 @@ export class Item {
     this.quantity = this.validateQuantity(quantity);
     this.categoryId = categoryId;
     this.isPacked = Boolean(isPacked);
-    this.isToBuy = Boolean(isToBuy);
+    this.isPending = Boolean(isPending);
     this.checklistId = checklistId;
     this.order = Number(order) || 0;
   }
@@ -95,11 +95,11 @@ export class Item {
    * @returns {Item} A new Item instance
    */
   static fromJSON(json) {
-    // Ensure isPacked and isToBuy are properly converted to boolean
+    // Ensure isPacked and isPending are properly converted to boolean
     const itemData = {
       ...json,
       isPacked: Boolean(json.isPacked),
-      isToBuy: Boolean(json.isToBuy),
+      isPending: Boolean(json.isPending),
     };
     return new Item(itemData);
   }
@@ -115,7 +115,7 @@ export class Item {
       quantity: this.quantity,
       categoryId: this.categoryId,
       isPacked: this.isPacked,
-      isToBuy: this.isToBuy,
+      isPending: this.isPending,
       checklistId: this.checklistId,
       order: this.order,
     };

--- a/source/utils/constants.js
+++ b/source/utils/constants.js
@@ -47,4 +47,13 @@ export const THEME_COLORS = {
   // 2 Background colors
   BACKGROUND_PRIMARY: 'rgba(255, 255, 255, 1)', // white (cards, panels, sidebar)
   BACKGROUND_SECONDARY: 'rgba(248, 250, 252, 1)', // light gray (app background, hover states)
+
+  // Shopping cart theme colors
+  SHOPPING_CART: {
+    BACKGROUND: 'rgba(255, 247, 237, 1)', // orange-50 (light orange background)
+    TEXT: 'rgba(124, 45, 18, 1)', // orange-900 (dark orange text)
+    ACCENT: 'rgba(234, 88, 12, 1)', // orange-600 (accent color)
+    BUTTON: 'rgba(249, 115, 22, 1)', // orange-500 (button background)
+    BUTTON_HOVER: 'rgba(234, 88, 12, 1)', // orange-600 (button hover)
+  },
 };

--- a/source/utils/constants.js
+++ b/source/utils/constants.js
@@ -48,8 +48,8 @@ export const THEME_COLORS = {
   BACKGROUND_PRIMARY: 'rgba(255, 255, 255, 1)', // white (cards, panels, sidebar)
   BACKGROUND_SECONDARY: 'rgba(248, 250, 252, 1)', // light gray (app background, hover states)
 
-  // Shopping cart theme colors
-  SHOPPING_CART: {
+  // Pending items (to-buy / to-do) theme colors
+  PENDING_ITEMS: {
     BACKGROUND: 'rgba(255, 247, 237, 1)', // orange-50 (light orange background)
     TEXT: 'rgba(124, 45, 18, 1)', // orange-900 (dark orange text)
     ACCENT: 'rgba(234, 88, 12, 1)', // orange-600 (accent color)


### PR DESCRIPTION
This pull request introduces a "Pending" (to-buy/to-do) workflow so users can mark items they'd like to purchase or handle later and view them in a dedicated category. The feature adds a Persistent PendingItemsCategory component, a per-item isPending flag, and UI affordances to move items to/from Pending. Orders and translations updated accordingly.

Key changes:

Components / UI:
- Add `PendingItemsCategory.vue` to display items flagged as "isPending".
- Add controls in `Item.vue` to mark/unmark items as isPending and move items into Pending.
- Update `Category.vue` and `Checklist.vue` to support rendering the pending category and item movement.

Logic & persistence:
- Add `isPending` boolean to `Item` model and update `Item.js` accordingly.
- Update constants and helpers in constants.js to include pending category id/labels.
- Ensure moves and status changes persist via existing localStorage/data services and keep ordering consistent.

Documentation:
- Update product-spec.md to document the pending workflow and verification steps.
- Update locale strings (en.json, zh-TW.json) for new labels and actions.