### PR TITLE
feat: Add copy and drag-to-reorder functionality in sidebar

### DIFF
--- a/docs/product-spec.md
+++ b/docs/product-spec.md
@@ -375,7 +375,7 @@ Notes:
 ```javascript
 {
   id: string,           // Unique identifier
-  name: string,         // Checklist name
+  name: string,         // Checklist name (can be empty - UI provides default)
   startDate: string,    // Start date (ISO)
   endDate: string,      // End date (ISO)
   order: number         // Display order (default: 0)

--- a/source/App.vue
+++ b/source/App.vue
@@ -42,6 +42,7 @@ Created: 2025-09-19
           @toggle-sidebar="toggleSidebar"
           @create-checklist="handleChecklistCreate"
           @select-checklist="selectedChecklistId = $event"
+          @edit-checklist="handleChecklistEdit"
           @delete-checklist="handleChecklistDelete"
         />
       </div>
@@ -61,6 +62,7 @@ Created: 2025-09-19
         @toggle-sidebar="toggleSidebar"
         @create-checklist="handleChecklistCreate"
         @select-checklist="selectedChecklistId = $event"
+        @edit-checklist="handleChecklistEdit"
         @delete-checklist="handleChecklistDelete"
       />
     </div>
@@ -399,6 +401,17 @@ async function handleChecklistCreate() {
  */
 async function handleChecklistUpdate(checklist) {
   await handleAsyncAction(updateChecklist, checklist);
+}
+
+/**
+ * Handle checklist edit from sidebar - select the checklist and mark for edit
+ * @param {string} checklistId - The ID of the checklist to edit
+ */
+function handleChecklistEdit(checklistId) {
+  // Select the checklist first
+  selectedChecklistId.value = checklistId;
+  // Mark it for editing
+  newlyCreatedChecklistId.value = checklistId;
 }
 
 /**

--- a/source/App.vue
+++ b/source/App.vue
@@ -159,6 +159,7 @@ const {
   initialize,
   createChecklist,
   updateChecklist,
+  updateMultipleChecklists,
   deleteChecklist,
   duplicateChecklist,
   createCategory,
@@ -480,10 +481,8 @@ async function handleChecklistDelete(checklistId) {
  * @param {Array} reorderedChecklists - Array of checklists with updated order
  */
 async function handleChecklistMove(reorderedChecklists) {
-  // Update all checklists in parallel for better performance
-  await Promise.all(
-    reorderedChecklists.map((checklist) => handleAsyncAction(updateChecklist, checklist))
-  );
+  // Update all checklists in a single transaction to avoid race conditions
+  await handleAsyncAction(updateMultipleChecklists, reorderedChecklists);
 }
 
 // ------------------------------------------------------------------------------

--- a/source/App.vue
+++ b/source/App.vue
@@ -44,6 +44,7 @@ Created: 2025-09-19
           @select-checklist="selectedChecklistId = $event"
           @edit-checklist="handleChecklistEdit"
           @delete-checklist="handleChecklistDelete"
+          @move:checklists="handleChecklistMove"
         />
       </div>
     </teleport>
@@ -64,6 +65,7 @@ Created: 2025-09-19
         @select-checklist="selectedChecklistId = $event"
         @edit-checklist="handleChecklistEdit"
         @delete-checklist="handleChecklistDelete"
+        @move:checklists="handleChecklistMove"
       />
     </div>
 
@@ -325,7 +327,7 @@ async function handleItemMove(moveData) {
 // ------------------------------------------------------------------------------
 
 /**
- * Create a new category with default name
+ * Create a new category with default values
  */
 async function handleCategoryCreate() {
   // Find the highest order among all categories
@@ -383,11 +385,16 @@ async function handleCategoryReorder(reorderedCategories) {
 // ------------------------------------------------------------------------------
 
 /**
- * Create a new checklist with default name
+ * Create a new checklist with default values
  */
 async function handleChecklistCreate() {
+  // Find the highest order among all checklists
+  const maxOrder =
+    checklists.value.length > 0 ? Math.max(...checklists.value.map((cl) => cl.order || 0)) : -1;
+
   const newChecklistData = {
     name: t('checklist.defaultName'),
+    order: maxOrder + 1,
   };
   const newChecklist = await handleAsyncAction(createChecklist, newChecklistData);
   if (newChecklist) {
@@ -427,6 +434,17 @@ async function handleChecklistDelete(checklistId) {
   if (selectedChecklistId.value === checklistId) {
     // Switch to first available checklist
     selectedChecklistId.value = checklists.value[0]?.id || null;
+  }
+}
+
+/**
+ * Handle checklist drag-and-drop movement or reordering
+ * @param {Array} reorderedChecklists - Array of checklists with updated order
+ */
+async function handleChecklistMove(reorderedChecklists) {
+  // Update all checklists with new order
+  for (const checklist of reorderedChecklists) {
+    await handleAsyncAction(updateChecklist, checklist);
   }
 }
 

--- a/source/App.vue
+++ b/source/App.vue
@@ -21,7 +21,7 @@ Created: 2025-09-19
     <!-- Mobile Topbar -->
     <Topbar
       v-if="isMobileViewport"
-      :title="selectedChecklist ? selectedChecklist.destination : 'Packing List'"
+      :title="selectedChecklist ? selectedChecklist.name : 'Packing List'"
       @toggle="toggleSidebar"
       @new="handleChecklistCreate"
     />
@@ -43,6 +43,7 @@ Created: 2025-09-19
           @create-checklist="handleChecklistCreate"
           @select-checklist="selectedChecklistId = $event"
           @edit-checklist="handleChecklistEdit"
+          @copy-checklist="handleChecklistCopy"
           @delete-checklist="handleChecklistDelete"
           @move:checklists="handleChecklistMove"
         />
@@ -64,6 +65,7 @@ Created: 2025-09-19
         @create-checklist="handleChecklistCreate"
         @select-checklist="selectedChecklistId = $event"
         @edit-checklist="handleChecklistEdit"
+        @copy-checklist="handleChecklistCopy"
         @delete-checklist="handleChecklistDelete"
         @move:checklists="handleChecklistMove"
       />
@@ -87,12 +89,15 @@ Created: 2025-09-19
           :newly-created-category-id="newlyCreatedCategoryId"
           :newly-created-checklist-id="newlyCreatedChecklistId"
           @update:checklist="handleChecklistUpdate"
+          @copy:checklist="handleChecklistCopy"
           @delete:checklist="handleChecklistDelete"
           @create:item="handleItemCreate"
           @update:item="handleItemUpdate"
+          @copy:item="handleItemCopy"
           @delete:item="handleItemDelete"
           @create:category="handleCategoryCreate"
           @update:category="handleCategoryUpdate"
+          @copy:category="handleCategoryCopy"
           @delete:category="handleCategoryDelete"
           @reorder:categories="handleCategoryReorder"
           @move:item="handleItemMove"
@@ -155,14 +160,17 @@ const {
   createChecklist,
   updateChecklist,
   deleteChecklist,
+  duplicateChecklist,
   createCategory,
   getCategories,
   updateCategory,
   deleteCategory,
+  duplicateCategory,
   createItem,
   getItems,
   updateItem,
   deleteItem,
+  duplicateItem,
 } = usePackingLists();
 
 // ------------------------------------------------------------------------------
@@ -285,6 +293,14 @@ async function handleItemUpdate(item) {
 }
 
 /**
+ * Handle item copy
+ * @param {string} itemId - The ID of the item to copy
+ */
+async function handleItemCopy(itemId) {
+  await handleAsyncAction(duplicateItem, itemId);
+}
+
+/**
  * Delete an item by ID
  * @param {string} itemId - The ID of the item to delete
  */
@@ -359,6 +375,14 @@ async function handleCategoryUpdate(category) {
 }
 
 /**
+ * Handle category copy
+ * @param {string} categoryId - The ID of the category to copy
+ */
+async function handleCategoryCopy(categoryId) {
+  await handleAsyncAction(duplicateCategory, categoryId);
+}
+
+/**
  * Delete a category by ID
  * @param {string} categoryId - The ID of the category to delete
  */
@@ -419,6 +443,18 @@ function handleChecklistEdit(checklistId) {
   selectedChecklistId.value = checklistId;
   // Mark it for editing
   newlyCreatedChecklistId.value = checklistId;
+}
+
+/**
+ * Handle checklist copy from sidebar
+ * @param {string} checklistId - The ID of the checklist to copy
+ */
+async function handleChecklistCopy(checklistId) {
+  const result = await handleAsyncAction(duplicateChecklist, checklistId);
+  if (result) {
+    // Select the new checklist
+    selectedChecklistId.value = result.id;
+  }
 }
 
 /**

--- a/source/App.vue
+++ b/source/App.vue
@@ -453,6 +453,8 @@ async function handleChecklistCopy(checklistId) {
   const result = await handleAsyncAction(duplicateChecklist, checklistId);
   if (result) {
     // Select the new checklist
+    // Note: duplicateChecklist internally calls getChecklists() via await,
+    // ensuring all data is loaded before this assignment executes
     selectedChecklistId.value = result.id;
   }
 }
@@ -478,10 +480,10 @@ async function handleChecklistDelete(checklistId) {
  * @param {Array} reorderedChecklists - Array of checklists with updated order
  */
 async function handleChecklistMove(reorderedChecklists) {
-  // Update all checklists with new order
-  for (const checklist of reorderedChecklists) {
-    await handleAsyncAction(updateChecklist, checklist);
-  }
+  // Update all checklists in parallel for better performance
+  await Promise.all(
+    reorderedChecklists.map((checklist) => handleAsyncAction(updateChecklist, checklist))
+  );
 }
 
 // ------------------------------------------------------------------------------

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -32,7 +32,8 @@ Created: 2025-09-19
         />
         <h3
           v-else
-          class="text-primary cursor-pointer rounded p-1 text-xl font-semibold hover:bg-gray-50"
+          class="text-primary cursor-pointer rounded p-1 text-xl font-semibold leading-snug hover:bg-gray-50"
+          style="word-break: break-word; overflow-wrap: break-word"
           @click="startEdit"
         >
           {{ category.name }}

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -46,6 +46,7 @@ Created: 2025-09-19
         alignment="left"
         class="ml-2"
         @edit="startEdit"
+        @copy="$emit('copy:category', category.id)"
         @delete="handleDelete"
       />
     </div>
@@ -89,6 +90,7 @@ Created: 2025-09-19
               :category-completed="isCompleted"
               :is-dragging="draggingItemId === item.id"
               @update:item="$emit('update:item', $event)"
+              @copy:item="$emit('copy:item', $event)"
               @delete:item="$emit('delete:item', $event)"
             />
           </div>
@@ -153,9 +155,11 @@ const props = defineProps({
 // Emits
 const emit = defineEmits([
   'update:item',
+  'copy:item',
   'delete:item',
   'create:item',
   'update:category',
+  'copy:category',
   'delete:category',
   'move:item',
 ]);

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -2,7 +2,7 @@
 ================================================================================
 File: source/components/Checklist.vue
 Description: Checklist component - displays a checklist with categories and items
-             for a specific travel destination.
+             for a specific trip.
 Author: Sheng-Wei Chang
 License: MIT (SPDX: MIT)
 Created: 2025-09-19
@@ -16,7 +16,7 @@ Created: 2025-09-19
       <!-- Header content -->
       <div class="mb-3 flex items-center justify-between gap-4">
         <div class="flex min-w-0 grow items-center gap-4">
-          <!-- Editable destination name -->
+          <!-- Editable checklist name -->
           <div
             class="flex min-w-0 grow"
             @blur="handleEditBlur"
@@ -24,11 +24,11 @@ Created: 2025-09-19
           >
             <input
               v-if="isEditing"
-              :id="`checklist-${checklist.id}-destination`"
-              ref="destinationInput"
-              v-model="editedDestination"
-              :name="`checklist-${checklist.id}-destination`"
-              :placeholder="$t('checklist.destination')"
+              :id="`checklist-${checklist.id}-name`"
+              ref="nameInput"
+              v-model="editedName"
+              :name="`checklist-${checklist.id}-name`"
+              :placeholder="$t('checklist.name')"
               class="text-primary w-full border-b-2 border-blue-300 bg-transparent p-1 text-3xl font-bold focus:border-blue-500 focus:outline-none"
               @keyup.enter="saveEdit"
               @keyup.escape="cancelEdit"
@@ -38,7 +38,7 @@ Created: 2025-09-19
               class="text-primary cursor-pointer truncate rounded p-1 text-3xl font-bold hover:bg-gray-50"
               @click="startEdit"
             >
-              {{ checklist.destination || $t('checklist.untitled') }}
+              {{ checklist.name || $t('checklist.untitled') }}
             </h2>
           </div>
 
@@ -95,6 +95,7 @@ Created: 2025-09-19
             alignment="left"
             class="ml-2"
             @edit="startEdit"
+            @copy="$emit('copy:checklist', checklist.id)"
             @delete="handleDelete"
           />
         </div>
@@ -150,9 +151,11 @@ Created: 2025-09-19
               :newly-created-item-id="newlyCreatedItemId"
               :newly-created-category-id="newlyCreatedCategoryId"
               @update:item="$emit('update:item', $event)"
+              @copy:item="$emit('copy:item', $event)"
               @delete:item="$emit('delete:item', $event)"
               @create:item="$emit('create:item', $event)"
               @update:category="$emit('update:category', $event)"
+              @copy:category="$emit('copy:category', $event)"
               @delete:category="$emit('delete:category', $event)"
               @move:item="handleItemMove"
             />
@@ -202,7 +205,7 @@ const props = defineProps({
       return (
         value &&
         typeof value.id === 'string' &&
-        typeof value.destination === 'string' &&
+        typeof value.name === 'string' &&
         typeof value.startDate === 'string' &&
         typeof value.endDate === 'string'
       );
@@ -233,11 +236,14 @@ const props = defineProps({
 // Emits
 const emit = defineEmits([
   'update:checklist',
+  'copy:checklist',
   'delete:checklist',
   'update:item',
+  'copy:item',
   'delete:item',
   'create:item',
   'update:category',
+  'copy:category',
   'delete:category',
   'create:category',
   'reorder:categories',
@@ -250,10 +256,10 @@ const emit = defineEmits([
 
 // Editing state
 const isEditing = ref(false);
-const editedDestination = ref('');
+const editedName = ref('');
 const editedStartDate = ref('');
 const editedEndDate = ref('');
-const destinationInput = ref(null);
+const nameInput = ref(null);
 const startDateInput = ref(null);
 const endDateInput = ref(null);
 
@@ -305,7 +311,7 @@ function handleEditBlur(_event) {
     // Check if focus is still within editing elements
     const activeElement = document.activeElement;
     const isStillEditing =
-      activeElement === destinationInput.value ||
+      activeElement === nameInput.value ||
       activeElement === startDateInput.value ||
       activeElement === endDateInput.value;
 
@@ -316,18 +322,18 @@ function handleEditBlur(_event) {
 }
 
 /**
- * Enter edit mode and focus on destination input
+ * Enter edit mode and focus on name input
  */
 async function startEdit() {
   isEditing.value = true;
-  editedDestination.value = props.checklist.destination;
+  editedName.value = props.checklist.name;
   editedStartDate.value = props.checklist.startDate;
   editedEndDate.value = props.checklist.endDate;
 
   await nextTick();
-  if (destinationInput.value) {
-    destinationInput.value.focus();
-    destinationInput.value.select();
+  if (nameInput.value) {
+    nameInput.value.focus();
+    nameInput.value.select();
   }
 }
 
@@ -335,14 +341,14 @@ async function startEdit() {
  * Save changes to checklist if any values were modified
  */
 function saveEdit() {
-  const hasDestinationChanged = editedDestination.value.trim() !== props.checklist.destination;
+  const hasNameChanged = editedName.value.trim() !== props.checklist.name;
   const hasStartDateChanged = editedStartDate.value !== props.checklist.startDate;
   const hasEndDateChanged = editedEndDate.value !== props.checklist.endDate;
 
-  if (hasDestinationChanged || hasStartDateChanged || hasEndDateChanged) {
+  if (hasNameChanged || hasStartDateChanged || hasEndDateChanged) {
     const updatedChecklist = {
       ...props.checklist,
-      destination: editedDestination.value.trim() || t('checklist.untitled'),
+      name: editedName.value.trim() || t('checklist.untitled'),
       startDate: editedStartDate.value,
       endDate: editedEndDate.value,
     };
@@ -356,7 +362,7 @@ function saveEdit() {
  */
 function cancelEdit() {
   isEditing.value = false;
-  editedDestination.value = props.checklist.destination;
+  editedName.value = props.checklist.name;
   editedStartDate.value = props.checklist.startDate;
   editedEndDate.value = props.checklist.endDate;
 }

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -207,7 +207,8 @@ const props = defineProps({
         typeof value.id === 'string' &&
         typeof value.name === 'string' &&
         typeof value.startDate === 'string' &&
-        typeof value.endDate === 'string'
+        typeof value.endDate === 'string' &&
+        typeof value.order === 'number'
       );
     },
   },

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -199,6 +199,7 @@ Created: 2025-09-19
       alignment="left"
       class="ml-0"
       @edit="startEdit"
+      @copy="$emit('copy:item', item.id)"
       @delete="handleDelete"
       @confirm-edit="saveEdit"
     />
@@ -253,7 +254,7 @@ const props = defineProps({
 });
 
 // Emits
-const emit = defineEmits(['update:item', 'delete:item']);
+const emit = defineEmits(['update:item', 'copy:item', 'delete:item']);
 
 // ------------------------------------------------------------------------------
 // States

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -57,11 +57,12 @@ Created: 2025-09-19
       <span
         v-else
         :class="[
-          'cursor-pointer rounded p-1 text-base hover:bg-gray-50',
+          'block cursor-pointer rounded p-1 text-base leading-snug hover:bg-gray-50',
           {
             'text-secondary line-through': item.isPacked,
           },
         ]"
+        style="word-break: break-word; overflow-wrap: break-word"
         @click="startEdit"
       >
         {{ item.name }}

--- a/source/components/OverflowMenu.vue
+++ b/source/components/OverflowMenu.vue
@@ -92,6 +92,26 @@ Created: 2025-09-19
       </button>
 
       <button
+        class="text-primary flex w-full items-center px-3 py-2 text-sm hover:bg-gray-100"
+        @click="handleCopy"
+      >
+        <svg
+          class="mr-2 size-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+          />
+        </svg>
+        {{ $t('common.copy') }}
+      </button>
+
+      <button
         class="flex w-full items-center px-3 py-2 text-sm text-red-600 hover:bg-red-50"
         @click="handleDelete"
       >
@@ -156,7 +176,7 @@ const props = defineProps({
 });
 
 // Emits
-const emit = defineEmits(['edit', 'delete', 'confirm-edit']);
+const emit = defineEmits(['edit', 'copy', 'delete', 'confirm-edit']);
 
 // ------------------------------------------------------------------------------
 // States
@@ -280,6 +300,14 @@ function toggleMenu() {
 function handleEdit() {
   showMenu.value = false;
   emit('edit');
+}
+
+/**
+ * Emit copy event and close the menu
+ */
+function handleCopy() {
+  showMenu.value = false;
+  emit('copy');
 }
 
 /**

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -95,6 +95,7 @@ Created: 2025-09-19
         <draggable
           v-model="draggableChecklists"
           item-key="id"
+          tag="ul"
           :group="{
             name: 'checklists',
             pull: false,

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -108,7 +108,7 @@ Created: 2025-09-19
             >
               <button
                 :class="[
-                  'w-full px-4 py-2 text-left transition-colors duration-300 ease-in-out',
+                  'grow px-4 py-2 text-left transition-colors duration-300 ease-in-out',
                   isExpanded || isMobile
                     ? [
                         selectedChecklistId === checklist.id
@@ -129,6 +129,21 @@ Created: 2025-09-19
                   {{ checklist.destination || $t('checklist.untitled') }}
                 </span>
               </button>
+
+              <!-- Overflow Menu for Checklist -->
+              <div
+                v-if="isExpanded || isMobile"
+                class="shrink-0 pr-1"
+              >
+                <OverflowMenu
+                  :item-id="checklist.id"
+                  menu-type="checklist"
+                  alignment="left"
+                  :use-group-hover="true"
+                  @edit="$emit('edit-checklist', checklist.id)"
+                  @delete="$emit('delete-checklist', checklist.id)"
+                />
+              </div>
             </div>
           </li>
         </ul>
@@ -251,6 +266,8 @@ Created: 2025-09-19
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import OverflowMenu from './OverflowMenu.vue';
+
 // ------------------------------------------------------------------------------
 // Internationalization (i18n)
 // ------------------------------------------------------------------------------
@@ -293,7 +310,13 @@ defineProps({
 });
 
 // Emits
-defineEmits(['toggle-sidebar', 'create-checklist', 'select-checklist']);
+defineEmits([
+  'toggle-sidebar',
+  'create-checklist',
+  'select-checklist',
+  'edit-checklist',
+  'delete-checklist',
+]);
 
 // ------------------------------------------------------------------------------
 // States

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -120,7 +120,6 @@ Created: 2025-09-19
                   selectedChecklistId === checklist.id && (isExpanded || isMobile)
                     ? 'bg-gray-100'
                     : 'hover:bg-gray-100',
-                  draggingChecklistId === checklist.id ? 'cursor-grabbing' : 'cursor-grab',
                 ]"
               >
                 <button
@@ -131,6 +130,8 @@ Created: 2025-09-19
                           selectedChecklistId === checklist.id
                             ? 'text-primary font-medium'
                             : 'text-secondary',
+                          // Apply cursor styles only when dragging is enabled
+                          draggingChecklistId === checklist.id ? 'cursor-grabbing' : 'cursor-grab',
                         ]
                       : '',
                   ]"
@@ -484,9 +485,9 @@ function closeLanguageMenuOnScroll() {
  * @param {object} event - Sortable drag event
  */
 function onChecklistDragStart(event) {
-  const checklistElement = event.item.querySelector('[data-checklist-id]') || event.item;
-  if (checklistElement.dataset.checklistId) {
-    draggingChecklistId.value = checklistElement.dataset.checklistId;
+  // The data-checklist-id attribute is on the <li> element (event.item itself)
+  if (event.item.dataset.checklistId) {
+    draggingChecklistId.value = event.item.dataset.checklistId;
   }
 }
 

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -115,7 +115,7 @@ Created: 2025-09-19
               class="whitespace-nowrap"
             >
               <div
-                class="group flex items-center rounded-lg px-1 transition-colors duration-200"
+                class="group relative flex items-center rounded-lg px-1 transition-colors duration-200"
                 :class="[
                   selectedChecklistId === checklist.id && (isExpanded || isMobile)
                     ? 'bg-gray-100'
@@ -125,7 +125,7 @@ Created: 2025-09-19
               >
                 <button
                   :class="[
-                    'grow px-4 py-2 text-left transition-colors duration-300 ease-in-out',
+                    'min-w-0 grow px-4 py-2 pr-8 text-left transition-colors duration-300 ease-in-out',
                     isExpanded || isMobile
                       ? [
                           selectedChecklistId === checklist.id
@@ -137,7 +137,7 @@ Created: 2025-09-19
                   @click="$emit('select-checklist', checklist.id)"
                 >
                   <span
-                    class="inline-block transition-all duration-300 ease-in-out"
+                    class="block truncate transition-all duration-300 ease-in-out"
                     :class="{
                       '-translate-x-4 opacity-0': !isExpanded && !isMobile,
                       'translate-x-0 opacity-100 delay-200': isExpanded || isMobile,
@@ -150,7 +150,7 @@ Created: 2025-09-19
                 <!-- Overflow Menu for Checklist -->
                 <div
                   v-if="isExpanded || isMobile"
-                  class="shrink-0 pr-1"
+                  class="absolute right-1 shrink-0"
                 >
                   <OverflowMenu
                     :item-id="checklist.id"

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -143,7 +143,7 @@ Created: 2025-09-19
                       'translate-x-0 opacity-100 delay-200': isExpanded || isMobile,
                     }"
                   >
-                    {{ checklist.destination || $t('checklist.untitled') }}
+                    {{ checklist.name || $t('checklist.untitled') }}
                   </span>
                 </button>
 
@@ -158,6 +158,7 @@ Created: 2025-09-19
                     alignment="left"
                     :use-group-hover="true"
                     @edit="$emit('edit-checklist', checklist.id)"
+                    @copy="$emit('copy-checklist', checklist.id)"
                     @delete="$emit('delete-checklist', checklist.id)"
                   />
                 </div>
@@ -334,6 +335,7 @@ const emit = defineEmits([
   'create-checklist',
   'select-checklist',
   'edit-checklist',
+  'copy-checklist',
   'delete-checklist',
   'move:checklists',
 ]);

--- a/source/components/Sidebar.vue
+++ b/source/components/Sidebar.vue
@@ -117,14 +117,13 @@ Created: 2025-09-19
               <div
                 class="group relative flex items-center rounded-lg px-1 transition-colors duration-200"
                 :class="[
-                  selectedChecklistId === checklist.id && (isExpanded || isMobile)
-                    ? 'bg-gray-100'
-                    : 'hover:bg-gray-100',
+                  selectedChecklistId === checklist.id ? 'bg-gray-100' : 'hover:bg-gray-100',
                 ]"
               >
                 <button
                   :class="[
-                    'min-w-0 grow px-4 py-2 pr-8 text-left transition-colors duration-300 ease-in-out',
+                    'min-w-0 grow py-2 text-left transition-colors duration-300 ease-in-out',
+                    isExpanded || isMobile ? 'px-4 pr-8' : 'flex items-center justify-center px-3',
                     isExpanded || isMobile
                       ? [
                           selectedChecklistId === checklist.id
@@ -133,18 +132,27 @@ Created: 2025-09-19
                           // Apply cursor styles only when dragging is enabled
                           draggingChecklistId === checklist.id ? 'cursor-grabbing' : 'cursor-grab',
                         ]
-                      : '',
+                      : [
+                          selectedChecklistId === checklist.id
+                            ? 'text-primary font-medium'
+                            : 'text-secondary',
+                        ],
                   ]"
                   @click="$emit('select-checklist', checklist.id)"
                 >
+                  <!-- Expanded: show full name -->
                   <span
+                    v-if="isExpanded || isMobile"
                     class="block truncate transition-all duration-300 ease-in-out"
-                    :class="{
-                      '-translate-x-4 opacity-0': !isExpanded && !isMobile,
-                      'translate-x-0 opacity-100 delay-200': isExpanded || isMobile,
-                    }"
                   >
                     {{ checklist.name || $t('checklist.untitled') }}
+                  </span>
+                  <!-- Collapsed: show first character -->
+                  <span
+                    v-else
+                    class="block"
+                  >
+                    {{ (checklist.name || $t('checklist.untitled')).charAt(0).toUpperCase() }}
                   </span>
                 </button>
 

--- a/source/composables/usePackingLists.js
+++ b/source/composables/usePackingLists.js
@@ -106,6 +106,14 @@ export function usePackingLists() {
       const preCategories = (raw.categories || []).map((cat) => Category.fromJSON(cat));
       const preItems = (raw.items || []).map((it) => Item.fromJSON(it));
 
+      // Ensure all checklists have order values and sort them
+      preChecklists.forEach((checklist, index) => {
+        if (typeof checklist.order === 'undefined') {
+          checklist.order = index;
+        }
+      });
+      preChecklists.sort((a, b) => (a.order || 0) - (b.order || 0));
+
       // Load checklists
       checklists.value = preChecklists;
       // If no selected checklist yet, pick the first
@@ -155,11 +163,11 @@ export function usePackingLists() {
 
   /**
    * Get all checklists from storage
-   * @returns {Promise<Array>} Array of checklist objects
+   * @returns {Promise<Array>} Array of checklist objects sorted by order
    */
   async function getChecklists() {
     const result = await loadData(() => dataService.getChecklists(), 'Error getting checklists');
-    checklists.value = result || [];
+    checklists.value = (result || []).sort((a, b) => (a.order || 0) - (b.order || 0));
     if (checklists.value.length > 0 && !selectedChecklistId.value) {
       selectedChecklistId.value = checklists.value[0].id;
     }

--- a/source/composables/usePackingLists.js
+++ b/source/composables/usePackingLists.js
@@ -107,12 +107,19 @@ export function usePackingLists() {
       const preItems = (raw.items || []).map((it) => Item.fromJSON(it));
 
       // Ensure all checklists have order values and sort them
+      const checklistsToUpdate = [];
       preChecklists.forEach((checklist, index) => {
         if (typeof checklist.order === 'undefined') {
           checklist.order = index;
+          checklistsToUpdate.push(checklist);
         }
       });
       preChecklists.sort((a, b) => (a.order || 0) - (b.order || 0));
+
+      // Persist missing order values to localStorage for old checklists
+      if (checklistsToUpdate.length > 0) {
+        await Promise.all(checklistsToUpdate.map((cl) => dataService.updateChecklist(cl.toJSON())));
+      }
 
       // Load checklists
       checklists.value = preChecklists;

--- a/source/composables/usePackingLists.js
+++ b/source/composables/usePackingLists.js
@@ -199,6 +199,24 @@ export function usePackingLists() {
   }
 
   /**
+   * Update multiple checklists in a single transaction
+   * This prevents race conditions when updating multiple checklists in parallel
+   * @param {Array<object>} checklistsData - Array of checklist data to update
+   * @returns {Promise<Array<object>|null>} Array of updated checklists or null on error
+   */
+  async function updateMultipleChecklists(checklistsData) {
+    const result = await loadData(
+      () => dataService.updateMultipleChecklists(checklistsData),
+      'Error updating checklists'
+    );
+    if (result) {
+      await getChecklists();
+      return result;
+    }
+    return null;
+  }
+
+  /**
    * Delete a checklist and update selection if needed
    * @param {string} checklistId - Checklist ID to delete
    * @returns {Promise<void>}
@@ -455,6 +473,7 @@ export function usePackingLists() {
     createChecklist,
     getChecklists,
     updateChecklist,
+    updateMultipleChecklists,
     deleteChecklist,
     duplicateChecklist,
 

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -22,7 +22,7 @@
     "name": "Checklist Name",
     "deleteConfirm": "Are you sure you want to delete this checklist?",
     "cannotDeleteLast": "Cannot delete the last checklist",
-    "defaultName": "My New Checklist",
+    "defaultName": "New Checklist",
     "pleaseCreate": "Please create a new checklist first"
   },
   "category": {

--- a/source/locales/en.json
+++ b/source/locales/en.json
@@ -1,10 +1,12 @@
 {
   "common": {
     "edit": "Edit",
+    "copy": "Copy",
     "delete": "Delete",
     "cancel": "Cancel",
     "save": "Save",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "copySuffix": " (Copy)"
   },
   "sidebar": {
     "title": "Checklists",
@@ -17,11 +19,11 @@
   },
   "checklist": {
     "untitled": "Untitled Checklist",
-    "destination": "Destination",
+    "name": "Checklist Name",
     "deleteConfirm": "Are you sure you want to delete this checklist?",
     "cannotDeleteLast": "Cannot delete the last checklist",
     "defaultName": "My New Checklist",
-    "pleaseCreate": "Please create a new checklist first."
+    "pleaseCreate": "Please create a new checklist first"
   },
   "category": {
     "newCategory": "New Category",

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -21,7 +21,7 @@
     "deleteConfirm": "確定要刪除這個清單嗎？",
     "cannotDeleteLast": "無法刪除最後一個清單",
     "defaultName": "我的新清單",
-    "pleaseCreate": "請先建立一個新清單。"
+    "pleaseCreate": "請先建立一個新清單"
   },
   "category": {
     "newCategory": "新增分類",

--- a/source/locales/zh-TW.json
+++ b/source/locales/zh-TW.json
@@ -1,10 +1,12 @@
 {
   "common": {
     "edit": "編輯",
+    "copy": "複製",
     "delete": "刪除",
     "cancel": "取消",
     "save": "儲存",
-    "confirm": "確認"
+    "confirm": "確認",
+    "copySuffix": " (複製)"
   },
   "sidebar": {
     "title": "清單列表",
@@ -17,10 +19,10 @@
   },
   "checklist": {
     "untitled": "未命名清單",
-    "destination": "目的地",
+    "name": "清單名稱",
     "deleteConfirm": "確定要刪除這個清單嗎？",
     "cannotDeleteLast": "無法刪除最後一個清單",
-    "defaultName": "我的新清單",
+    "defaultName": "新清單",
     "pleaseCreate": "請先建立一個新清單"
   },
   "category": {

--- a/source/models/Checklist.js
+++ b/source/models/Checklist.js
@@ -31,17 +31,20 @@ export class Checklist {
    * @param {string} root0.destination - Destination location for the trip
    * @param {string} root0.startDate - Trip start date in ISO format (YYYY-MM-DD)
    * @param {string} root0.endDate - Trip end date in ISO format (YYYY-MM-DD)
+   * @param {number} root0.order - Display order for the checklist (default: 0)
    */
   constructor({
     id = generateSecureId('checklist-'),
     destination = '',
     startDate = new Date().toISOString().slice(0, 10),
     endDate = new Date().toISOString().slice(0, 10),
+    order = 0,
   } = {}) {
     this.id = id;
     this.destination = this.validateDestination(destination);
     this.startDate = startDate;
     this.endDate = endDate;
+    this.order = order;
   }
 
   /**
@@ -79,6 +82,7 @@ export class Checklist {
       destination: this.destination,
       startDate: this.startDate,
       endDate: this.endDate,
+      order: this.order,
     };
   }
 }

--- a/source/models/Checklist.js
+++ b/source/models/Checklist.js
@@ -56,11 +56,16 @@ export class Checklist {
     if (typeof name !== 'string') {
       throw new Error('Name must be a string');
     }
-    // Allow empty name for initial creation, but enforce max length
-    if (name.length > VALIDATION.NAME_MAX_LENGTH) {
+
+    // Trim whitespace
+    const trimmedName = name.trim();
+
+    // Enforce max length (allow empty string - UI/Service layer handles defaults)
+    if (trimmedName.length > VALIDATION.NAME_MAX_LENGTH) {
       throw new Error(`Name must be less than ${VALIDATION.NAME_MAX_LENGTH} characters`);
     }
-    return name;
+
+    return trimmedName;
   }
 
   /**

--- a/source/models/Checklist.js
+++ b/source/models/Checklist.js
@@ -28,39 +28,39 @@ export class Checklist {
    * Checklist class constructor
    * @param {object} root0 - Checklist configuration object
    * @param {string} root0.id - Unique identifier for the checklist
-   * @param {string} root0.destination - Destination location for the trip
+   * @param {string} root0.name - Name of the checklist
    * @param {string} root0.startDate - Trip start date in ISO format (YYYY-MM-DD)
    * @param {string} root0.endDate - Trip end date in ISO format (YYYY-MM-DD)
    * @param {number} root0.order - Display order for the checklist (default: 0)
    */
   constructor({
     id = generateSecureId('checklist-'),
-    destination = '',
+    name = '',
     startDate = new Date().toISOString().slice(0, 10),
     endDate = new Date().toISOString().slice(0, 10),
     order = 0,
   } = {}) {
     this.id = id;
-    this.destination = this.validateDestination(destination);
+    this.name = this.validateName(name);
     this.startDate = startDate;
     this.endDate = endDate;
     this.order = order;
   }
 
   /**
-   * Validate checklist destination
-   * @param {string} destination - The destination to validate
-   * @returns {string} Validated destination
+   * Validate checklist name
+   * @param {string} name - The name to validate
+   * @returns {string} Validated name
    */
-  validateDestination(destination) {
-    if (typeof destination !== 'string') {
-      throw new Error('Destination must be a string');
+  validateName(name) {
+    if (typeof name !== 'string') {
+      throw new Error('Name must be a string');
     }
-    // Allow empty destination for initial creation, but enforce max length
-    if (destination.length > VALIDATION.NAME_MAX_LENGTH) {
-      throw new Error(`Destination must be less than ${VALIDATION.NAME_MAX_LENGTH} characters`);
+    // Allow empty name for initial creation, but enforce max length
+    if (name.length > VALIDATION.NAME_MAX_LENGTH) {
+      throw new Error(`Name must be less than ${VALIDATION.NAME_MAX_LENGTH} characters`);
     }
-    return destination;
+    return name;
   }
 
   /**
@@ -79,7 +79,7 @@ export class Checklist {
   toJSON() {
     return {
       id: this.id,
-      destination: this.destination,
+      name: this.name,
       startDate: this.startDate,
       endDate: this.endDate,
       order: this.order,

--- a/source/services/localStorageService.js
+++ b/source/services/localStorageService.js
@@ -301,6 +301,9 @@ export class LocalStorageService extends DataService {
       return cl;
     });
 
+    // Find the insertion index (right after the original checklist)
+    const insertionIndex = data.checklists.findIndex((cl) => cl.id === id) + 1;
+
     // Get all categories and items for the original checklist
     const originalCategories = (data.categories || []).filter((cat) => cat.checklistId === id);
     const originalItems = (data.items || []).filter((item) => item.checklistId === id);
@@ -329,8 +332,8 @@ export class LocalStorageService extends DataService {
       });
     });
 
-    // Add to storage
-    data.checklists = [...data.checklists, newChecklist.toJSON()];
+    // Insert new checklist at the correct position (right after the original)
+    data.checklists.splice(insertionIndex, 0, newChecklist.toJSON());
     data.categories = [...(data.categories || []), ...newCategories.map((c) => c.toJSON())];
     data.items = [...(data.items || []), ...newItems.map((i) => i.toJSON())];
 


### PR DESCRIPTION
This pull request enhances management by introducing a "copy" feature for checklists, categories, and items, and adds drag-and-drop reordering for checklists in the sidebar. It also renames the checklist property `destination` to `name` for better clarity.

Key changes:

Components / UI:
-   Enable drag-and-drop reordering for checklists in `Sidebar.vue`.
-   Add a "Copy" action to the `OverflowMenu` for checklists, categories, and items, complete with a new icon and i18n text.
-   Ensure that when a checklist/category/item is copied, it appears with a " (Copy)" suffix just below the original checklist/category/item.
-   Rename the input label for a checklist's name from "Destination" to "Checklist Name" in the UI.

Logic & persistence:
- Persist checklist order after drag-and-drop operations by updating the `order` property on all checklists.
- Implement `duplicateChecklist`, `duplicateCategory`, and `duplicateItem` logic in `usePackingLists.js` and `localStorageService.js` to create deep copies and persist them.
- Update the `Checklist` model, replacing `destination` with `name`.
- Data migrations in `localStorageService.js` now handle the transition from `destination` to `name`.

Documentation:
- Update `product-spec.md` to reflect the new copy and checklist reordering functionalities, and the `destination` to `name` property change.