### PR TITLE
fix: Improve IME input handling for Enter key across edit components

### DIFF
--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -26,9 +26,11 @@ Created: 2025-09-19
           v-model="editedName"
           :name="`category-${category.id}-name`"
           class="w-full border-b border-blue-300 bg-transparent p-1 text-xl font-semibold text-slate-800 focus:border-blue-500 focus:outline-none"
-          @keyup.enter="saveEdit"
+          @keydown.enter="handleEnterKey"
           @keyup.escape="cancelEdit"
           @blur="saveEdit"
+          @compositionstart="handleCompositionStart"
+          @compositionend="handleCompositionEnd"
         />
         <h3
           v-else
@@ -173,6 +175,7 @@ const emit = defineEmits([
 const isEditing = ref(false);
 const editedName = ref('');
 const editInput = ref(null);
+const isComposing = ref(false);
 
 // Drag state
 const draggingItemId = ref(null);
@@ -215,6 +218,36 @@ const isCompleted = computed(() => {
 // ------------------------------------------------------------------------------
 // Editing functions
 // ------------------------------------------------------------------------------
+
+/**
+ * Handle composition start (IME input begins)
+ */
+function handleCompositionStart() {
+  isComposing.value = true;
+}
+
+/**
+ * Handle composition end (IME input completes)
+ */
+function handleCompositionEnd() {
+  isComposing.value = false;
+}
+
+/**
+ * Handle Enter key press - only save if not in IME composition
+ * @param {KeyboardEvent} event - The keyboard event
+ */
+function handleEnterKey(event) {
+  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  if (isComposing.value) {
+    event.preventDefault();
+    return;
+  }
+  // Prevent default to avoid form submission or other default behaviors
+  event.preventDefault();
+  // Otherwise, save the edit
+  saveEdit();
+}
 
 /**
  * Enter edit mode and focus on the category name input

--- a/source/components/Category.vue
+++ b/source/components/Category.vue
@@ -28,7 +28,7 @@ Created: 2025-09-19
           class="w-full border-b border-blue-300 bg-transparent p-1 text-xl font-semibold text-slate-800 focus:border-blue-500 focus:outline-none"
           @keydown.enter="handleEnterKey"
           @keyup.escape="cancelEdit"
-          @blur="saveEdit"
+          @blur="handleBlur"
           @compositionstart="handleCompositionStart"
           @compositionend="handleCompositionEnd"
         />
@@ -238,15 +238,24 @@ function handleCompositionEnd() {
  * @param {KeyboardEvent} event - The keyboard event
  */
 function handleEnterKey(event) {
-  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  event.preventDefault();
+  // If currently composing (e.g., selecting Chinese characters), return early
   if (isComposing.value) {
-    event.preventDefault();
     return;
   }
-  // Prevent default to avoid form submission or other default behaviors
-  event.preventDefault();
   // Otherwise, save the edit
   saveEdit();
+}
+
+/**
+ * Handle blur event - save edit if not in IME composition
+ * Although modern browsers fire compositionend before blur,
+ * this check provides defensive programming against edge cases
+ */
+function handleBlur() {
+  if (!isComposing.value) {
+    saveEdit();
+  }
 }
 
 /**

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -324,19 +324,18 @@ function handleCompositionEnd() {
  * @param {KeyboardEvent} event - The keyboard event
  */
 function handleEnterKey(event) {
-  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  event.preventDefault();
+  // If currently composing (e.g., selecting Chinese characters), return early
   if (isComposing.value) {
-    event.preventDefault();
     return;
   }
-  // Prevent default to avoid form submission or other default behaviors
-  event.preventDefault();
   // Otherwise, save the edit
   saveEdit();
 }
 
 /**
  * Save edit when focus moves outside the edit area
+ * Includes IME composition check for defensive programming
  * @param {Event} _event - Blur event (unused)
  */
 function handleEditBlur(_event) {
@@ -349,7 +348,8 @@ function handleEditBlur(_event) {
       activeElement === startDateInput.value ||
       activeElement === endDateInput.value;
 
-    if (!isStillEditing && isEditing.value) {
+    // Only save if not editing and not in IME composition
+    if (!isStillEditing && isEditing.value && !isComposing.value) {
       saveEdit();
     }
   }, 10);

--- a/source/components/Checklist.vue
+++ b/source/components/Checklist.vue
@@ -30,8 +30,10 @@ Created: 2025-09-19
               :name="`checklist-${checklist.id}-name`"
               :placeholder="$t('checklist.name')"
               class="text-primary w-full border-b-2 border-blue-300 bg-transparent p-1 text-3xl font-bold focus:border-blue-500 focus:outline-none"
-              @keyup.enter="saveEdit"
+              @keydown.enter="handleEnterKey"
               @keyup.escape="cancelEdit"
+              @compositionstart="handleCompositionStart"
+              @compositionend="handleCompositionEnd"
             />
             <h2
               v-else
@@ -59,7 +61,7 @@ Created: 2025-09-19
                 :name="`checklist-${checklist.id}-start-date`"
                 type="date"
                 class="text-secondary w-28 rounded border border-gray-300 bg-transparent p-1 text-base focus:border-blue-500 focus:outline-none sm:w-auto sm:px-2"
-                @keyup.enter="saveEdit"
+                @keydown.enter="handleEnterKey"
                 @keyup.escape="cancelEdit"
               />
               <span class="text-secondary hidden md:inline">-</span>
@@ -71,7 +73,7 @@ Created: 2025-09-19
                 type="date"
                 :min="editedStartDate"
                 class="text-secondary w-28 rounded border border-gray-300 bg-transparent p-1 text-base focus:border-blue-500 focus:outline-none sm:w-auto sm:px-2"
-                @keyup.enter="saveEdit"
+                @keydown.enter="handleEnterKey"
                 @keyup.escape="cancelEdit"
               />
             </div>
@@ -263,6 +265,7 @@ const editedEndDate = ref('');
 const nameInput = ref(null);
 const startDateInput = ref(null);
 const endDateInput = ref(null);
+const isComposing = ref(false);
 
 // Drag state
 const draggingCategoryId = ref(null);
@@ -301,6 +304,36 @@ const draggableCategories = computed({
 // ------------------------------------------------------------------------------
 // Editing functions
 // ------------------------------------------------------------------------------
+
+/**
+ * Handle composition start (IME input begins)
+ */
+function handleCompositionStart() {
+  isComposing.value = true;
+}
+
+/**
+ * Handle composition end (IME input completes)
+ */
+function handleCompositionEnd() {
+  isComposing.value = false;
+}
+
+/**
+ * Handle Enter key press - only save if not in IME composition
+ * @param {KeyboardEvent} event - The keyboard event
+ */
+function handleEnterKey(event) {
+  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  if (isComposing.value) {
+    event.preventDefault();
+    return;
+  }
+  // Prevent default to avoid form submission or other default behaviors
+  event.preventDefault();
+  // Otherwise, save the edit
+  saveEdit();
+}
 
 /**
  * Save edit when focus moves outside the edit area

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -50,8 +50,10 @@ Created: 2025-09-19
           },
         ]"
         style="border-radius: 0"
-        @keyup.enter="saveEdit"
+        @keydown.enter="handleEnterKey"
         @keyup.escape="cancelEdit"
+        @compositionstart="handleCompositionStart"
+        @compositionend="handleCompositionEnd"
       />
 
       <span
@@ -266,6 +268,7 @@ const isHovered = ref(false);
 const isQuantityHovered = ref(false);
 const editedName = ref('');
 const editInput = ref(null);
+const isComposing = ref(false);
 
 // ------------------------------------------------------------------------------
 // Computed
@@ -293,6 +296,36 @@ const isItemPacked = computed({
 // ------------------------------------------------------------------------------
 // Functions
 // ------------------------------------------------------------------------------
+
+/**
+ * Handle composition start (IME input begins)
+ */
+function handleCompositionStart() {
+  isComposing.value = true;
+}
+
+/**
+ * Handle composition end (IME input completes)
+ */
+function handleCompositionEnd() {
+  isComposing.value = false;
+}
+
+/**
+ * Handle Enter key press - only save if not in IME composition
+ * @param {KeyboardEvent} event - The keyboard event
+ */
+function handleEnterKey(event) {
+  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  if (isComposing.value) {
+    event.preventDefault();
+    return;
+  }
+  // Prevent default to avoid form submission or other default behaviors
+  event.preventDefault();
+  // Otherwise, save the edit
+  saveEdit();
+}
 
 /**
  * Toggle the pending state of the item (to-buy / to-do)

--- a/source/components/Item.vue
+++ b/source/components/Item.vue
@@ -316,13 +316,11 @@ function handleCompositionEnd() {
  * @param {KeyboardEvent} event - The keyboard event
  */
 function handleEnterKey(event) {
-  // If currently composing (e.g., selecting Chinese characters), prevent default and return
+  event.preventDefault();
+  // If currently composing (e.g., selecting Chinese characters), return early
   if (isComposing.value) {
-    event.preventDefault();
     return;
   }
-  // Prevent default to avoid form submission or other default behaviors
-  event.preventDefault();
   // Otherwise, save the edit
   saveEdit();
 }
@@ -367,6 +365,7 @@ function decrementQuantity() {
 
 /**
  * Save edit when focus moves outside the edit area
+ * Includes IME composition check for defensive programming
  * @param {Event} _event - Blur event (unused)
  */
 function handleEditBlur(_event) {
@@ -376,7 +375,8 @@ function handleEditBlur(_event) {
     const activeElement = document.activeElement;
     const isStillEditing = activeElement === editInput.value;
 
-    if (!isStillEditing && isEditing.value) {
+    // Only save if not editing and not in IME composition
+    if (!isStillEditing && isEditing.value && !isComposing.value) {
       saveEdit();
     }
   }, 10);


### PR DESCRIPTION
This pull request fixes an issue where pressing Enter during IME (Input Method Editor) composition would prematurely save edits while users were still selecting characters in languages like Chinese or Japanese. The fix adds composition event handlers to properly detect and ignore Enter key presses during IME input, ensuring edits only save when the user has completed their input.

Key changes:

Components / UI:

- Add IME composition tracking (compositionstart/compositionend events) to Category.vue, Item.vue, and Checklist.vue
- Replace @keyup.enter with @keydown.enter and add conditional logic to ignore Enter key during active IME composition

Logic & persistence:
- Prevent premature saving when users are selecting characters via IME input methods
- Improve UX for multilingual users typing in Chinese, Japanese, Korean, and other languages requiring IME